### PR TITLE
docs: update all documentation for Phase 1-2 rework

### DIFF
--- a/.claude/ARCHITECTURE.md
+++ b/.claude/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-*Last updated: 2026-01-03*
+*Last updated: 2026-04-01*
 
 System design for PromoAtlas PIM. For implementation patterns, see PATTERNS.md.
 
@@ -9,14 +9,14 @@ System design for PromoAtlas PIM. For implementation patterns, see PATTERNS.md.
 ```
 ┌─────────────────┐         ┌─────────────────┐         ┌─────────────────┐
 │  React Frontend │────────▶│  Strapi Backend │────────▶│   PostgreSQL    │
-│  (Port 3000)    │  REST   │  (Port 1337)    │  pg     │   (Coolify)     │
+│  (Port 3000)    │  REST   │  (Port 1337)    │  pg     │  (local:5433)   │
 └─────────────────┘         └─────────────────┘         └─────────────────┘
                                      │
                     ┌────────────────┼────────────────┐
                     ▼                ▼                ▼
             ┌───────────┐    ┌───────────┐    ┌───────────┐
-            │ R2 Images │    │ Promidata │    │  Gemini   │
-            │           │    │   API     │    │ RAG Store │
+            │ R2/SeaweedFS   │ Promidata │    │MeiliSearch│
+            │  (Images) │    │   API     │    │  (7700)   │
             └───────────┘    └───────────┘    └───────────┘
 ```
 
@@ -87,11 +87,10 @@ endpoints: { suppliers: '/Import/Import.txt', categories: '/Import/CAT.csv' }
 |--------|-------------|---------|
 | `supplier-sync` | 1 | Full supplier sync (sequential) |
 | `product-family` | 3 | Group by a_number, create Product + Variants |
-| `image-upload` | 10 | Download from Promidata → R2 |
+| `image-upload` | 10 | Download from Promidata → R2/SeaweedFS |
 | `meilisearch-sync` | 5 | Index products for search |
-| `gemini-sync` | 5 | Upload to FileSearchStore |
 
-**Redis**: Local Docker (dev port 6380), Remote (prod)
+**Redis**: Local Docker (dev port 6382), Remote (prod)
 
 **Monitoring**: Bull Board at `/admin/queue-dashboard`
 
@@ -104,18 +103,6 @@ Redis-based distributed locking prevents duplicate syncs:
 - Stop: `sync:promidata:stop:{id}` (5min TTL)
 
 **API**: `GET /api/promidata-sync/active`, `POST /api/promidata-sync/stop/:id`
-
-### Gemini FileSearchStore
-
-**Location**: `backend/src/api/gemini-sync/services/gemini-file-search.ts`
-
-**Key Points**:
-- FileSearchStore ≠ Files API (separate namespaces)
-- Use `fileSearchStoreNames` not `fileSearchStoreIds` for queries
-- Track sync via `gemini_file_uri` field on Product
-- No individual file deletion (only full store)
-
-**Dashboard**: `/admin/gemini-dashboard`
 
 ## Frontend Architecture
 

--- a/.claude/DECISIONS.md
+++ b/.claude/DECISIONS.md
@@ -1,8 +1,30 @@
 # Architectural Decisions
 
-*Last updated: 2026-01-03*
+*Last updated: 2026-04-01*
 
 Decision log for PromoAtlas PIM. Keep decisions concise: Context → Decision → Consequences.
+
+---
+
+## [2026-04-01] Phase 1 Rework: Remove Gemini, Upgrade Strapi, Fix Schemas
+
+**Context**: Major rework toward MeiliSearch hybrid search + Vercel AI SDK + assistant-ui. Existing Gemini RAG integration scrapped. Vercel deployment replaced by Coolify for both FE and BE. Schema analysis found broken price tier extraction and dead fields.
+
+**Decisions**:
+1. **Remove Gemini RAG entirely** (~8,000 lines) — replaced by MeiliSearch hybrid search (planned)
+2. **Remove Vercel** — Coolify handles both FE and BE deployment
+3. **Upgrade Strapi 5.17 → 5.41** — 24 minor versions, all packages aligned
+4. **Fix extractPriceTiers()** — was reading non-existent `price_1`..`price_8`, now reads real `ProductPriceCountryBased[region]`
+5. **Schema cleanup**: Remove `model_name`, `embroidery_sizes` (dead). Add `ean`, `minimum_order_quantity`, `quantity_increments`, `price_region`, `depth` (missing from Promidata)
+6. **Pricing region strategy**: BENELUX priority, EURO fallback, first available as last resort. Each product has exactly one region.
+7. **Supplier name**: Use static `supplier-names.ts` map (60 entries) + `UnstructuredInformation.SupplierNameToShow` fallback
+8. **Local Docker dev stack**: PostgreSQL:5433, Redis:6382, MeiliSearch:7700 (no more shared prod Redis)
+9. **Keep R2 for now** — migrating to SeaweedFS in next phase
+10. **Keep custom BullMQ** (2,600 lines) — official plugin is trivial 80-line wrapper, not worth adopting
+
+**Consequences**: 4 workers (was 5). Full re-sync needed after schema fixes. Promidata field map documented (723 JSON paths in `backend/docs/PROMIDATA_FIELD_MAP.md`).
+
+**PRs**: #27 (Gemini removal), #28 (Strapi upgrade + deep cleanup), #29 (schema + transformer fixes)
 
 ---
 

--- a/.claude/GOTCHAS.md
+++ b/.claude/GOTCHAS.md
@@ -1,44 +1,45 @@
 # Known Issues & Workarounds
 
-*Last updated: 2026-01-03*
+*Last updated: 2026-04-01*
 
 Active gotchas in PromoAtlas PIM. Fixed issues archived in git history.
-
-## Gemini FileSearchStore
-
-| Issue | Description | Workaround |
-|-------|-------------|------------|
-| **Namespace Confusion** | `files.list()` doesn't show FileSearchStore files (separate namespace) | Verify with semantic search, not `files.list()` |
-| **No Individual Deletion** | Can only delete entire store, not individual files | Accept file accumulation; track sync in Strapi via `gemini_file_uri` |
-| **Wrong API Format** | `fileSearchStoreIds` doesn't work | Use `config.tools[{ fileSearch: { fileSearchStoreNames: [storeId] } }]` |
-
-**Key Insight**: If semantic search returns products, files ARE uploaded correctly.
 
 ## Backend
 
 | Issue | Description | Workaround |
 |-------|-------------|------------|
 | **Strapi 5 ID Types** | `entityService` requires numeric `id`, but URLs/relations use `documentId` (UUID) | Use `db.query().findOne({ where: { documentId } })` to get numeric `id` first |
+| **entityService Deprecated** | `strapi.entityService` deprecated in 5.40+, 48 calls in 11 files | Still works in 5.41. Migrate to `strapi.documents()` incrementally before Strapi 6 |
 | **Promidata SKU Case** | Promidata JSON uses `Sku` (camelCase), not `SKU` or `sku` | Always check all three: `variants[0].SKU \|\| variants[0].sku \|\| variants[0].Sku` |
 | **Repeatable Components** | Strapi 5 expects arrays for repeatable components, `undefined` causes errors | Return `[]` instead of `undefined` for empty repeatable fields |
 | **Hash Sync Limitations** | If Promidata changes product but keeps same hash, update missed | Run full sync periodically: `UPDATE products SET promidata_hash = NULL;` |
-| **Image Upload Timeout** | Large images/slow network cause 30s timeout | Sync one supplier at a time; increase timeout if needed |
+| **Pricing Region Dynamic** | Region key is BENELUX or EURO depending on supplier, not standardized | Use `selectPriceRegion()` helper: BENELUX > EURO > first available |
+| **HexColor Two Locations** | `NonLanguageDependedProductDetails.HexColor` is usually null | Also check `ProductDetails.{lang}.UnstructuredInformation.HexColor` (A403 pattern) |
+| **ConfigurationFields Non-Standard** | A73 uses `49P_CONFIG_1` instead of `Color` | Check `ConfigurationNameTranslated` for hints, don't assume field names |
+| **Languages Not Universal** | NL + DE always present, EN missing from A403, FR missing from A73 | Always handle missing languages gracefully in extractors |
 | **Connection Pool Exhaustion** | Large syncs may exhaust 10-connection pool | Sync during low-traffic; increase pool in `database.ts` |
-| **JSON Field Indexing** | Multilingual JSON fields can't be indexed efficiently | Add computed columns: `name_en TEXT GENERATED ALWAYS AS (name->>'en') STORED` |
-| **Upstash KEYS Disabled** | `client.keys('pattern*')` fails on Upstash | Use `SCAN` with cursor iteration instead |
+
+## Promidata Integration
+
+| Issue | Description | Workaround |
+|-------|-------------|------------|
+| **Rate Limiting** | No retry logic for 429 errors | `promidata-client.ts` has exponential backoff built in |
+| **String Booleans** | `ProductFiltersByGroup` values are `"True"` not `true` | Parse as strings, not booleans |
+| **Root vs Child Data** | Root has zeroed dimensions/prices, only 1 price tier | Always use ChildProducts[] for real data |
 
 ## Frontend
 
 | Issue | Description | Workaround |
 |-------|-------------|------------|
 | **Image Aspect Ratio** | Hard-coded thresholds (1.2-1.8) may not fit all images | Default `contain` is safe; some images have white space |
-| **Brand Filter Performance** | Fetches 1000 products to extract unique brands | Works for now; add backend `/api/products/brands` endpoint for scale |
+| **Frontend Being Rebuilt** | Current frontend will be replaced with assistant-ui + Vercel AI SDK | Don't invest in current FE fixes |
 
-## Promidata Integration
+## Infrastructure
 
 | Issue | Description | Workaround |
 |-------|-------------|------------|
-| **Rate Limiting** | No retry logic for 429 errors | Add delay between requests; implement exponential backoff |
+| **Dual MeiliSearch Sync** | Plugin writes to `pim_products`, custom service to `MEILISEARCH_INDEX_NAME` | Consolidate to one path (planned) |
+| **CORS localhost only** | `middlewares.ts` only allows localhost origins | Add production FE domain before deploying |
 
 ## Security Notes
 
@@ -47,4 +48,4 @@ Active gotchas in PromoAtlas PIM. Fixed issues archived in git history.
 
 ---
 
-*Update when discovering new issues. Archive fixed issues by removing them. Testing/monitoring gaps covered in STACK.md.*
+*Update when discovering new issues. Archive fixed issues by removing them.*

--- a/.claude/STACK.md
+++ b/.claude/STACK.md
@@ -1,6 +1,6 @@
 # Tech Stack
 
-*Last updated: 2025-12-05 14:50*
+*Last updated: 2026-04-01*
 
 Complete technology stack for PromoAtlas PIM system with versions and rationale.
 
@@ -9,17 +9,17 @@ Complete technology stack for PromoAtlas PIM system with versions and rationale.
 ## Backend Stack (Strapi 5)
 
 ### Core Framework
-- **Strapi 5.17.0** - Headless CMS for content management
+- **Strapi 5.41.1** - Headless CMS for content management
   - **Why**: Provides robust API, content-type builder, admin panel, plugin ecosystem
   - **Node Requirement**: 18.0.0 - 22.x.x
   - **Key Features**: Content types, components, lifecycle hooks, permissions
 
 ### Strapi Plugins
-- **@strapi/plugin-users-permissions** (5.17.0) - Authentication & authorization
-- **@strapi/plugin-cloud** (5.17.0) - Cloud integrations
-- **@strapi/plugin-documentation** - OpenAPI/Swagger API documentation
-- **strapi-provider-cloudflare-r2** (^0.3.0) - Cloudflare R2 storage provider
-- **@strapi/provider-upload-aws-s3** (5.18.0) - S3-compatible upload provider
+- **@strapi/plugin-users-permissions** (5.41.1) - Authentication & authorization
+- **@strapi/plugin-cloud** (5.41.1) - Cloud integrations
+- **@strapi/plugin-documentation** (5.41.1) - OpenAPI/Swagger API documentation
+- **strapi-provider-cloudflare-r2** (^0.3.0) - Cloudflare R2 storage provider (migrating to SeaweedFS)
+- **@strapi/provider-upload-aws-s3** (5.41.1) - S3-compatible upload provider
 - **strapi-plugin-meilisearch** - Meilisearch integration for product search
 
 ### Database
@@ -44,14 +44,6 @@ Complete technology stack for PromoAtlas PIM system with versions and rationale.
   - **Features**: Faceted search, typo tolerance, instant results
   - **Integration**: strapi-plugin-meilisearch for automatic indexing
 
-### AI/RAG Integration
-- **@google/genai** (^1.30.0) - Google Gemini AI SDK
-  - **Why**: Semantic search and AI-powered product discovery
-  - **Feature**: FileSearchStore for RAG (Retrieval Augmented Generation)
-  - **Store**: `promoatlas-product-catalog-xfex8hxfyifx`
-  - **Data Flow**: Strapi → Meilisearch → Gemini FileSearchStore
-  - **Tracking**: `gemini_file_uri` field on Product tracks sync status
-
 ### HTTP Client
 - **node-fetch** (2.7.0) - HTTP requests for Promidata API integration
   - **Why**: Simple, Promise-based API for external data fetching
@@ -63,12 +55,11 @@ Complete technology stack for PromoAtlas PIM system with versions and rationale.
   - **Why**: Handles long-running sync operations, concurrent job processing, job retries
   - **Redis Client**: ioredis (^5.3.0)
   - **Redis Provider**: Local Docker (dev) / Coolify Redis (prod)
-  - **Workers**: 5 active workers for parallel processing
+  - **Workers**: 4 active workers for parallel processing
     - `supplier-sync` (concurrency: 1) - Processes supplier sync jobs sequentially
     - `product-family` (concurrency: 3) - Creates product families with parallelism
-    - `image-upload` (concurrency: 10) - High-concurrency image uploads to R2
+    - `image-upload` (concurrency: 10) - High-concurrency image uploads
     - `meilisearch-sync` (concurrency: 5) - Syncs products to Meilisearch index
-    - `gemini-sync` (concurrency: 5) - Syncs products to Gemini FileSearchStore
   - **Features**: Job retries, progress tracking, failure handling, queue monitoring
   - **Configuration**: Lazy Redis connection to prevent startup issues
 - **@bull-board/api** + **@bull-board/koa** - Queue monitoring dashboard

--- a/.claude/STARTUP.md
+++ b/.claude/STARTUP.md
@@ -1,18 +1,25 @@
 # Startup Guide
 
-*Last updated: 2026-01-03*
+*Last updated: 2026-04-01*
 
 Quick setup and operations for PromoAtlas PIM.
 
 ## Prerequisites
 
 - Node.js 18-22
-- Docker (for local Redis)
+- Docker + Docker Compose (for local services)
 - Git
 
 ## Quick Start
 
-### 1. Backend
+### 1. Start Docker services
+
+```bash
+docker compose up -d
+# Starts: PostgreSQL (5433), Redis (6382), MeiliSearch (7700)
+```
+
+### 2. Backend
 
 ```bash
 cd backend
@@ -22,48 +29,12 @@ npm run build         # First time only
 npm run develop       # Start with hot-reload
 ```
 
-### 2. Frontend
+### 3. Frontend
 
 ```bash
 cd frontend
 npm install
 npm run dev           # Starts on port 3000+
-```
-
-### 3. Local Redis (Dev)
-
-```bash
-docker run -d --name promoatlas-redis -p 6380:6379 redis:alpine
-```
-
-## Environment Variables
-
-### Backend (.env) - Required
-
-```env
-# Database (Coolify PostgreSQL)
-DATABASE_URL=postgres://postgres:password@46.62.239.73:5432/postgres?sslmode=require
-DATABASE_CLIENT=postgres
-
-# Redis (local dev)
-REDIS_URL=redis://localhost:6380/0
-
-# Cloudflare R2
-R2_ACCESS_KEY_ID=xxx
-R2_SECRET_ACCESS_KEY=xxx
-R2_BUCKET_NAME=promo-atlas-images
-R2_PUBLIC_URL=https://bucket.account.r2.cloudflarestorage.com
-R2_ENDPOINT=https://account.r2.cloudflarestorage.com
-
-# Strapi (generate: node -e "console.log(require('crypto').randomBytes(16).toString('base64'))")
-APP_KEYS=key1,key2,key3,key4
-ADMIN_JWT_SECRET=xxx
-API_TOKEN_SALT=xxx
-TRANSFER_TOKEN_SALT=xxx
-JWT_SECRET=xxx
-
-HOST=0.0.0.0
-PORT=1337
 ```
 
 ## Service URLs
@@ -75,7 +46,15 @@ PORT=1337
 | API | http://localhost:1337/api |
 | Frontend | http://localhost:3000 |
 | Queue Dashboard | http://localhost:1337/admin/queue-dashboard |
-| Gemini Dashboard | http://localhost:1337/admin/gemini-dashboard |
+| MeiliSearch | http://localhost:7700 |
+
+## Docker Services
+
+| Service | Container | Port | Credentials |
+|---------|-----------|------|-------------|
+| PostgreSQL 17 | promoatlas-postgres | localhost:5433 | strapi / strapi123 / db: promoatlas |
+| Redis 7 | promoatlas-redis | localhost:6382 | no auth |
+| MeiliSearch | promoatlas-meilisearch | localhost:7700 | key: promoatlas-dev-key |
 
 ## Common Commands
 
@@ -90,6 +69,11 @@ npm run start        # Production server
 cd frontend
 npm run dev          # Vite dev server
 npm run build        # Production build
+
+# Docker
+docker compose up -d     # Start all services
+docker compose down      # Stop all services
+docker compose logs -f   # View logs
 ```
 
 ## Running Sync
@@ -102,15 +86,9 @@ curl -X POST http://localhost:1337/api/promidata-sync/start \
   -H "Authorization: Bearer $JWT_TOKEN"
 ```
 
-**Force full re-sync**:
+**Force full re-sync** (bypasses hash check):
 ```sql
 UPDATE products SET promidata_hash = NULL;
-```
-
-## Database Access
-
-```bash
-PGPASSWORD="password" psql -h 46.62.239.73 -U postgres -d postgres
 ```
 
 ## Troubleshooting
@@ -118,35 +96,26 @@ PGPASSWORD="password" psql -h 46.62.239.73 -U postgres -d postgres
 | Issue | Solution |
 |-------|----------|
 | `ECONNRESET` on DB | Set `ssl: { rejectUnauthorized: false }` in `database.ts` |
-| `ECONNREFUSED` | Check DATABASE_URL and server connectivity |
-| R2 `Access Denied` | Verify R2_ACCESS_KEY_ID/SECRET |
+| `ECONNREFUSED` | Check Docker services: `docker compose ps` |
 | Admin won't load | Run `npm run build` first |
 | Port in use | `lsof -ti:PORT \| xargs kill -9` |
 | npm install fails | `rm -rf node_modules package-lock.json && npm install` |
-| API 404 in frontend | Ensure backend is running on 1337 |
 | Empty products | Check Strapi permissions (Public role) |
+| Empty price tiers | Run full re-sync after schema changes |
 
 ## First Time Setup
 
-1. Start backend: `npm run develop`
-2. Visit http://localhost:1337/admin
-3. Create admin account
-4. Suppliers auto-bootstrap on first run (56 total)
+1. `docker compose up -d` — Start PostgreSQL, Redis, MeiliSearch
+2. `cd backend && npm install && npm run build && npm run develop`
+3. Visit http://localhost:1337/admin — Create admin account
+4. Suppliers auto-bootstrap on first run (59 total)
 5. Run first sync via admin panel
 
-## Deployment
+## Deployment (Coolify)
 
-**Backend** (Coolify/Docker):
-```bash
-npm run build && npm run start
-# Set NODE_ENV=production and production env vars
-```
-
-**Frontend** (Vercel):
-```bash
-npm run build  # Output: dist/
-vercel --prod
-```
+Both backend and frontend deploy via Coolify using `docker-compose.coolify.yml`:
+- Push to `develop` → Staging deploy
+- Push to `main` → Production deploy
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,32 +1,32 @@
 # PromoAtlas PIM System
 
-*Last updated: 2026-01-03*
+*Last updated: 2026-04-01*
 
 ## System Status ✅
 
-**OPERATIONAL**: Backend (1337), Frontend (3000), PostgreSQL (Coolify), Redis (local:6380), 5 BullMQ workers, Gemini RAG
+**OPERATIONAL**: Backend (1337), Frontend (3000), PostgreSQL (local:5433), Redis (local:6382), MeiliSearch (local:7700), 4 BullMQ workers
 
 ## Quick Context
 
-Strapi 5-based PIM for promotional products. Key features:
-- **56 Promidata suppliers** with hash-based incremental sync (89% efficiency)
+Strapi 5.41-based PIM for promotional products. Key features:
+- **59 Promidata suppliers** with hash-based incremental sync
 - **Product → ProductVariant** hierarchy for size/color variants
-- **Gemini FileSearchStore** for semantic search
-- **Meilisearch** for exact search
-- **Cloudflare R2** for images
+- **MeiliSearch** for product search (upgrading to hybrid search)
+- **Cloudflare R2** for images (migrating to SeaweedFS)
+- **Coolify** for deployment (both FE and BE)
 
 ## Essential Commands
 
 ```bash
+# Docker services (postgres, redis, meilisearch)
+docker compose up -d
+
 # Backend
 cd backend && npm run develop   # Start dev server
 cd backend && npm run build     # Build admin panel
 
 # Frontend
 cd frontend && npm run dev      # Start Vite dev server
-
-# Local Redis (dev)
-docker start promoatlas-redis   # Or: docker run -d --name promoatlas-redis -p 6380:6379 redis:alpine
 ```
 
 **URLs**: Backend http://localhost:1337/admin | Frontend http://localhost:3000
@@ -62,6 +62,7 @@ Detailed docs auto-load when needed:
 ## MCP Tools
 
 - **Strapi MCP** - Content management
+- **MeiliSearch MCP** - Search index operations
 - **Context7 MCP** - Documentation lookup
 - **Playwright MCP** - Browser automation
 


### PR DESCRIPTION
- CLAUDE.md: Update status (4 workers, local Docker, Strapi 5.41, no Gemini)
- STACK.md: Strapi 5.41.1, remove Gemini/Google AI, 4 workers
- ARCHITECTURE.md: Remove Gemini section, update ports and diagram
- DECISIONS.md: Add 2026-04-01 rework decision (10 sub-decisions)
- GOTCHAS.md: Remove Gemini gotchas, add new ones (hex color, pricing region, entityService deprecated, non-standard config fields)
- STARTUP.md: Docker compose setup, new ports, MeiliSearch, updated troubleshooting