### PR TITLE
feat: MeiliSearch hybrid search with OpenAI embeddings

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -28,13 +28,6 @@ R2_BUCKET_NAME=data-vault
 R2_ENDPOINT=https://your-account-id.r2.cloudflarestorage.com
 R2_PUBLIC_URL=https://pub-xxxxx.r2.dev
 
-# Cloudflare AutoRAG Integration
-CLOUDFLARE_ACCOUNT_ID=your_account_id
-CLOUDFLARE_API_TOKEN=your_api_token
-CLOUDFLARE_RAG_NAME=your_rag_name
-MALFINI_R2_ACCESS_KEY_ID=your_access_key
-MALFINI_R2_SECRET_ACCESS_KEY=your_secret_key
-
 # Promidata Integration
 PROMIDATA_BASE_URL=https://promi-dl.de/Profiles/Live/your-profile-id
 
@@ -54,8 +47,11 @@ BULLMQ_JOB_TIMEOUT_FAMILY=300000
 BULLMQ_JOB_TIMEOUT_IMAGE=120000
 BULLMQ_JOB_TIMEOUT_MEILISEARCH=30000
 
-# Meilisearch (Local Docker)
+# Meilisearch (Local Docker v1.41+)
 MEILISEARCH_HOST=http://localhost:7700
 MEILISEARCH_ADMIN_KEY=promoatlas-dev-key
 MEILISEARCH_SEARCH_KEY=promoatlas-dev-key
 MEILISEARCH_INDEX_NAME=pim_products
+
+# OpenAI (for MeiliSearch hybrid search embeddings)
+OPENAI_API_KEY=sk-your-openai-api-key

--- a/backend/scripts/setup-meilisearch-embedder.js
+++ b/backend/scripts/setup-meilisearch-embedder.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * Setup MeiliSearch Hybrid Search Embedder
+ *
+ * Configures the OpenAI text-embedding-3-small embedder on the pim_products index.
+ * Run this once after setting up a fresh MeiliSearch instance.
+ *
+ * Requirements:
+ * - MeiliSearch v1.6+ running
+ * - OPENAI_API_KEY in .env
+ * - MEILISEARCH_HOST and MEILISEARCH_ADMIN_KEY in .env
+ *
+ * Usage: node scripts/setup-meilisearch-embedder.js
+ */
+
+require('dotenv').config();
+
+const MEILISEARCH_HOST = process.env.MEILISEARCH_HOST || 'http://localhost:7700';
+const MEILISEARCH_KEY = process.env.MEILISEARCH_ADMIN_KEY || '';
+const OPENAI_KEY = process.env.OPENAI_API_KEY || '';
+const INDEX_NAME = process.env.MEILISEARCH_INDEX_NAME || 'pim_products';
+
+async function setup() {
+  console.log('🔍 Setting up MeiliSearch hybrid search embedder...\n');
+
+  // Validate
+  if (!OPENAI_KEY) {
+    console.error('❌ OPENAI_API_KEY not set in .env');
+    process.exit(1);
+  }
+
+  // Check MeiliSearch version
+  const versionRes = await fetch(`${MEILISEARCH_HOST}/version`, {
+    headers: { 'Authorization': `Bearer ${MEILISEARCH_KEY}` }
+  });
+  const version = await versionRes.json();
+  console.log(`MeiliSearch version: ${version.pkgVersion}`);
+
+  const [major, minor] = version.pkgVersion.split('.').map(Number);
+  if (major < 1 || (major === 1 && minor < 6)) {
+    console.error('❌ MeiliSearch v1.6+ required for hybrid search');
+    process.exit(1);
+  }
+
+  // Configure embedder
+  console.log(`\nConfiguring embedder on index "${INDEX_NAME}"...`);
+
+  const res = await fetch(`${MEILISEARCH_HOST}/indexes/${INDEX_NAME}/settings`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${MEILISEARCH_KEY}`,
+    },
+    body: JSON.stringify({
+      embedders: {
+        product_search: {
+          source: 'openAi',
+          apiKey: OPENAI_KEY,
+          model: 'text-embedding-3-small',
+          dimensions: 1536,
+          documentTemplate: [
+            'Product: {% if doc.name_en %}{{ doc.name_en }}{% elsif doc.name_de %}{{ doc.name_de }}{% elsif doc.name_fr %}{{ doc.name_fr }}{% else %}Unknown{% endif %}.',
+            'Brand: {{ doc.brand }}. Category: {{ doc.category }}.',
+            '{% if doc.description_en %}{{ doc.description_en | truncatewords: 30 }}{% elsif doc.description_de %}{{ doc.description_de | truncatewords: 30 }}{% endif %}',
+            'Colors: {{ doc.colors | join: ", " }}. Supplier: {{ doc.supplier_name }}.',
+          ].join(' '),
+          documentTemplateMaxBytes: 800,
+        },
+      },
+    }),
+  });
+
+  const result = await res.json();
+
+  if (result.taskUid !== undefined) {
+    console.log(`✅ Embedder configuration enqueued (task: ${result.taskUid})`);
+
+    // Wait for task to complete
+    let status = 'enqueued';
+    while (status !== 'succeeded' && status !== 'failed') {
+      await new Promise(r => setTimeout(r, 1000));
+      const taskRes = await fetch(`${MEILISEARCH_HOST}/tasks/${result.taskUid}`, {
+        headers: { 'Authorization': `Bearer ${MEILISEARCH_KEY}` }
+      });
+      const task = await taskRes.json();
+      status = task.status;
+    }
+
+    if (status === 'succeeded') {
+      console.log('✅ Embedder configured successfully!');
+      console.log('\nNext steps:');
+      console.log('  1. Run: node scripts/reindex-meilisearch.js');
+      console.log('  2. Embeddings will be generated automatically for all products');
+      console.log('  3. Search with: ?q=your+query&semantic=0.5');
+    } else {
+      console.error('❌ Embedder configuration failed');
+    }
+  } else {
+    console.error('❌ Unexpected response:', result);
+  }
+}
+
+setup().catch(err => {
+  console.error('❌ Setup failed:', err.message);
+  process.exit(1);
+});

--- a/backend/src/api/product/controllers/product.ts
+++ b/backend/src/api/product/controllers/product.ts
@@ -51,6 +51,7 @@ export default factories.createCoreController('api::product.product', ({ strapi 
         q = '',                           // Search query
         limit = 20,                       // Results per page
         offset = 0,                       // Pagination offset
+        semantic,                         // Semantic ratio: 0-1 (0=keyword, 1=semantic, default=0.5)
         facets = '',                      // Comma-separated facets (e.g., "supplier_code,brand,category")
         sort = '',                        // Comma-separated sort fields (e.g., "price_min:asc,updatedAt:desc")
         // Filters
@@ -104,11 +105,18 @@ export default factories.createCoreController('api::product.product', ({ strapi 
       // Parse sort (comma-separated list to array)
       const sortList = sort ? String(sort).split(',').map(s => s.trim()).filter(Boolean) : [];
 
+      // Build hybrid search config if semantic ratio is specified
+      const semanticRatio = semantic !== undefined ? parseFloat(String(semantic)) : undefined;
+      const hybrid = semanticRatio !== undefined && !isNaN(semanticRatio)
+        ? { semanticRatio: Math.max(0, Math.min(1, semanticRatio)), embedder: 'product_search' }
+        : undefined;
+
       // Execute Meilisearch search
       const searchResult = await meilisearchService.searchProducts({
         query: q,
         limit: parseInt(String(limit), 10),
         offset: parseInt(String(offset), 10),
+        hybrid,
         filters,
         facets: facetsList,
         sort: sortList,

--- a/backend/src/api/product/services/meilisearch-types.ts
+++ b/backend/src/api/product/services/meilisearch-types.ts
@@ -117,6 +117,12 @@ export interface MeilisearchSearchOptions {
   limit?: number;                 // Number of results (default: 20)
   offset?: number;                // Pagination offset
 
+  // Hybrid search (semantic + keyword)
+  hybrid?: {
+    semanticRatio?: number;       // 0.0 = pure keyword, 1.0 = pure semantic (default: 0.5)
+    embedder?: string;            // Embedder name (default: 'product_search')
+  };
+
   // Filters (Meilisearch filter syntax)
   filters?: string[];             // Array of filter expressions
 

--- a/backend/src/api/product/services/meilisearch.ts
+++ b/backend/src/api/product/services/meilisearch.ts
@@ -494,6 +494,7 @@ export class MeilisearchService {
       query = '',
       limit = 20,
       offset = 0,
+      hybrid,
       filters = [],
       facets = [],
       sort = [],
@@ -507,8 +508,8 @@ export class MeilisearchService {
       // Build filter string (AND logic)
       const filterString = filters.length > 0 ? filters.join(' AND ') : undefined;
 
-      // Execute search
-      const searchResults = await this.index!.search(query, {
+      // Build search params
+      const searchParams: any = {
         limit,
         offset,
         filter: filterString,
@@ -518,7 +519,18 @@ export class MeilisearchService {
         attributesToHighlight,
         attributesToCrop,
         cropLength,
-      });
+      };
+
+      // Add hybrid search if configured
+      if (hybrid) {
+        searchParams.hybrid = {
+          semanticRatio: hybrid.semanticRatio ?? 0.5,
+          embedder: hybrid.embedder || 'product_search',
+        };
+      }
+
+      // Execute search
+      const searchResults = await this.index!.search(query, searchParams);
 
       // Return normalized response
       return {

--- a/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2026-04-01T19:14:43.550Z"
+    "x-generation-date": "2026-04-02T09:18:29.038Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -6692,7 +6692,14 @@
         ],
         "properties": {
           "id": {
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "documentId": {
             "type": "string"
@@ -6705,7 +6712,14 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "documentId": {
                 "type": "string"
@@ -6718,7 +6732,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -6731,7 +6752,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -6748,7 +6776,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -6792,6 +6827,18 @@
                     "promidata_hash": {
                       "type": "string"
                     },
+                    "ean": {
+                      "type": "string"
+                    },
+                    "minimum_order_quantity": {
+                      "type": "integer"
+                    },
+                    "quantity_increments": {
+                      "type": "integer"
+                    },
+                    "price_region": {
+                      "type": "string"
+                    },
                     "battery_information": {
                       "type": "string"
                     },
@@ -6800,7 +6847,6 @@
                     },
                     "name": {},
                     "description": {},
-                    "model_name": {},
                     "short_description": {},
                     "material": {},
                     "customization": {},
@@ -6838,7 +6884,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -6852,6 +6905,7 @@
                         "caption": {
                           "type": "string"
                         },
+                        "focalPoint": {},
                         "width": {
                           "type": "integer"
                         },
@@ -6888,7 +6942,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -6900,7 +6961,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -6915,7 +6983,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -6928,7 +7003,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -6942,7 +7024,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -6956,6 +7045,7 @@
                                   "caption": {
                                     "type": "string"
                                   },
+                                  "focalPoint": {},
                                   "width": {
                                     "type": "integer"
                                   },
@@ -6992,7 +7082,14 @@
                                       "type": "object",
                                       "properties": {
                                         "id": {
-                                          "type": "number"
+                                          "oneOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            }
+                                          ]
                                         },
                                         "documentId": {
                                           "type": "string"
@@ -7004,7 +7101,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -7030,7 +7134,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -7063,7 +7174,14 @@
                                           "type": "object",
                                           "properties": {
                                             "id": {
-                                              "type": "number"
+                                              "oneOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "number"
+                                                }
+                                              ]
                                             },
                                             "documentId": {
                                               "type": "string"
@@ -7083,7 +7201,14 @@
                                                 "type": "object",
                                                 "properties": {
                                                   "id": {
-                                                    "type": "number"
+                                                    "oneOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      }
+                                                    ]
                                                   },
                                                   "documentId": {
                                                     "type": "string"
@@ -7097,7 +7222,14 @@
                                                 "type": "object",
                                                 "properties": {
                                                   "id": {
-                                                    "type": "number"
+                                                    "oneOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      }
+                                                    ]
                                                   },
                                                   "documentId": {
                                                     "type": "string"
@@ -7115,7 +7247,14 @@
                                                     "type": "object",
                                                     "properties": {
                                                       "id": {
-                                                        "type": "number"
+                                                        "oneOf": [
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "number"
+                                                          }
+                                                        ]
                                                       },
                                                       "documentId": {
                                                         "type": "string"
@@ -7138,7 +7277,14 @@
                                                     "type": "object",
                                                     "properties": {
                                                       "id": {
-                                                        "type": "number"
+                                                        "oneOf": [
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "number"
+                                                          }
+                                                        ]
                                                       },
                                                       "documentId": {
                                                         "type": "string"
@@ -7149,7 +7295,14 @@
                                                     "type": "object",
                                                     "properties": {
                                                       "id": {
-                                                        "type": "number"
+                                                        "oneOf": [
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "number"
+                                                          }
+                                                        ]
                                                       },
                                                       "documentId": {
                                                         "type": "string"
@@ -7165,7 +7318,14 @@
                                                       "type": "object",
                                                       "properties": {
                                                         "id": {
-                                                          "type": "number"
+                                                          "oneOf": [
+                                                            {
+                                                              "type": "string"
+                                                            },
+                                                            {
+                                                              "type": "number"
+                                                            }
+                                                          ]
                                                         },
                                                         "documentId": {
                                                           "type": "string"
@@ -7192,7 +7352,14 @@
                                               "type": "object",
                                               "properties": {
                                                 "id": {
-                                                  "type": "number"
+                                                  "oneOf": [
+                                                    {
+                                                      "type": "string"
+                                                    },
+                                                    {
+                                                      "type": "number"
+                                                    }
+                                                  ]
                                                 },
                                                 "documentId": {
                                                   "type": "string"
@@ -7203,7 +7370,14 @@
                                               "type": "object",
                                               "properties": {
                                                 "id": {
-                                                  "type": "number"
+                                                  "oneOf": [
+                                                    {
+                                                      "type": "string"
+                                                    },
+                                                    {
+                                                      "type": "number"
+                                                    }
+                                                  ]
                                                 },
                                                 "documentId": {
                                                   "type": "string"
@@ -7219,7 +7393,14 @@
                                                 "type": "object",
                                                 "properties": {
                                                   "id": {
-                                                    "type": "number"
+                                                    "oneOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      }
+                                                    ]
                                                   },
                                                   "documentId": {
                                                     "type": "string"
@@ -7252,7 +7433,14 @@
                                         "type": "object",
                                         "properties": {
                                           "id": {
-                                            "type": "number"
+                                            "oneOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "number"
+                                              }
+                                            ]
                                           },
                                           "documentId": {
                                             "type": "string"
@@ -7263,7 +7451,14 @@
                                         "type": "object",
                                         "properties": {
                                           "id": {
-                                            "type": "number"
+                                            "oneOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "number"
+                                              }
+                                            ]
                                           },
                                           "documentId": {
                                             "type": "string"
@@ -7279,7 +7474,14 @@
                                           "type": "object",
                                           "properties": {
                                             "id": {
-                                              "type": "number"
+                                              "oneOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "number"
+                                                }
+                                              ]
                                             },
                                             "documentId": {
                                               "type": "string"
@@ -7293,7 +7495,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -7309,7 +7518,14 @@
                                       "type": "object",
                                       "properties": {
                                         "id": {
-                                          "type": "number"
+                                          "oneOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            }
+                                          ]
                                         },
                                         "documentId": {
                                           "type": "string"
@@ -7339,7 +7555,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -7350,7 +7573,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -7366,7 +7596,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -7395,7 +7632,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -7406,7 +7650,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -7422,7 +7673,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -7438,7 +7696,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -7452,6 +7717,7 @@
                           "caption": {
                             "type": "string"
                           },
+                          "focalPoint": {},
                           "width": {
                             "type": "integer"
                           },
@@ -7488,7 +7754,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -7500,7 +7773,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -7526,7 +7806,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -7537,7 +7824,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -7553,7 +7847,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -7568,7 +7869,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -7582,6 +7890,7 @@
                         "caption": {
                           "type": "string"
                         },
+                        "focalPoint": {},
                         "width": {
                           "type": "integer"
                         },
@@ -7618,7 +7927,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -7630,7 +7946,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -7656,7 +7979,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -7667,7 +7997,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -7683,7 +8020,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -7712,7 +8056,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -7757,7 +8108,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -7769,7 +8127,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -7778,7 +8143,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -7835,7 +8207,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -7846,7 +8225,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -7862,7 +8248,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -7888,7 +8281,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -7899,7 +8299,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -7915,7 +8322,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -7931,7 +8345,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -7945,7 +8366,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -7969,7 +8397,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -7983,6 +8418,7 @@
                               "caption": {
                                 "type": "string"
                               },
+                              "focalPoint": {},
                               "width": {
                                 "type": "integer"
                               },
@@ -8019,7 +8455,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -8031,7 +8474,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -8057,7 +8507,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -8068,7 +8525,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -8084,7 +8548,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -8100,7 +8571,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -8114,6 +8592,7 @@
                                 "caption": {
                                   "type": "string"
                                 },
+                                "focalPoint": {},
                                 "width": {
                                   "type": "integer"
                                 },
@@ -8150,7 +8629,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -8162,7 +8648,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -8188,7 +8681,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -8199,7 +8699,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -8215,7 +8722,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -8232,7 +8746,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -8246,6 +8767,7 @@
                                 "caption": {
                                   "type": "string"
                                 },
+                                "focalPoint": {},
                                 "width": {
                                   "type": "integer"
                                 },
@@ -8282,7 +8804,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -8294,7 +8823,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -8320,7 +8856,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -8331,7 +8874,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -8347,7 +8897,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -8419,7 +8976,6 @@
                           "usb_item": {
                             "type": "boolean"
                           },
-                          "embroidery_sizes": {},
                           "is_service_base": {
                             "type": "boolean"
                           },
@@ -8430,7 +8986,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -8453,7 +9016,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -8464,7 +9034,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -8480,7 +9057,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -8514,7 +9098,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -8525,7 +9116,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -8541,7 +9139,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -8568,7 +9173,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -8579,7 +9191,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -8595,7 +9214,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -8611,7 +9237,14 @@
               "type": "object",
               "properties": {
                 "id": {
-                  "type": "number"
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
                 },
                 "documentId": {
                   "type": "string"
@@ -8628,7 +9261,14 @@
               "type": "object",
               "properties": {
                 "id": {
-                  "type": "number"
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
                 },
                 "documentId": {
                   "type": "string"
@@ -8652,7 +9292,14 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "documentId": {
                 "type": "string"
@@ -8663,7 +9310,14 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "documentId": {
                 "type": "string"
@@ -8679,7 +9333,14 @@
               "type": "object",
               "properties": {
                 "id": {
-                  "type": "number"
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
                 },
                 "documentId": {
                   "type": "string"
@@ -8704,7 +9365,14 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "length": {
             "type": "number",
@@ -8719,6 +9387,10 @@
             "format": "float"
           },
           "diameter": {
+            "type": "number",
+            "format": "float"
+          },
+          "depth": {
             "type": "number",
             "format": "float"
           },
@@ -8750,7 +9422,14 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "quantity": {
             "type": "integer"
@@ -8786,7 +9465,14 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "position_code": {
             "type": "string"
@@ -8867,6 +9553,18 @@
               "promidata_hash": {
                 "type": "string"
               },
+              "ean": {
+                "type": "string"
+              },
+              "minimum_order_quantity": {
+                "type": "integer"
+              },
+              "quantity_increments": {
+                "type": "integer"
+              },
+              "price_region": {
+                "type": "string"
+              },
               "battery_information": {
                 "type": "string"
               },
@@ -8875,7 +9573,6 @@
               },
               "name": {},
               "description": {},
-              "model_name": {},
               "short_description": {},
               "material": {},
               "customization": {},
@@ -9071,7 +9768,14 @@
         ],
         "properties": {
           "id": {
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "documentId": {
             "type": "string"
@@ -9115,6 +9819,18 @@
           "promidata_hash": {
             "type": "string"
           },
+          "ean": {
+            "type": "string"
+          },
+          "minimum_order_quantity": {
+            "type": "integer"
+          },
+          "quantity_increments": {
+            "type": "integer"
+          },
+          "price_region": {
+            "type": "string"
+          },
           "battery_information": {
             "type": "string"
           },
@@ -9123,7 +9839,6 @@
           },
           "name": {},
           "description": {},
-          "model_name": {},
           "short_description": {},
           "material": {},
           "customization": {},
@@ -9161,7 +9876,14 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "documentId": {
                 "type": "string"
@@ -9175,6 +9897,7 @@
               "caption": {
                 "type": "string"
               },
+              "focalPoint": {},
               "width": {
                 "type": "integer"
               },
@@ -9211,7 +9934,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -9223,7 +9953,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -9238,7 +9975,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -9251,7 +9995,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -9265,7 +10016,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -9279,6 +10037,7 @@
                         "caption": {
                           "type": "string"
                         },
+                        "focalPoint": {},
                         "width": {
                           "type": "integer"
                         },
@@ -9315,7 +10074,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -9327,7 +10093,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -9353,7 +10126,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -9386,7 +10166,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -9406,7 +10193,14 @@
                                       "type": "object",
                                       "properties": {
                                         "id": {
-                                          "type": "number"
+                                          "oneOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            }
+                                          ]
                                         },
                                         "documentId": {
                                           "type": "string"
@@ -9420,7 +10214,14 @@
                                       "type": "object",
                                       "properties": {
                                         "id": {
-                                          "type": "number"
+                                          "oneOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            }
+                                          ]
                                         },
                                         "documentId": {
                                           "type": "string"
@@ -9438,7 +10239,14 @@
                                           "type": "object",
                                           "properties": {
                                             "id": {
-                                              "type": "number"
+                                              "oneOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "number"
+                                                }
+                                              ]
                                             },
                                             "documentId": {
                                               "type": "string"
@@ -9461,7 +10269,14 @@
                                           "type": "object",
                                           "properties": {
                                             "id": {
-                                              "type": "number"
+                                              "oneOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "number"
+                                                }
+                                              ]
                                             },
                                             "documentId": {
                                               "type": "string"
@@ -9472,7 +10287,14 @@
                                           "type": "object",
                                           "properties": {
                                             "id": {
-                                              "type": "number"
+                                              "oneOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "number"
+                                                }
+                                              ]
                                             },
                                             "documentId": {
                                               "type": "string"
@@ -9488,7 +10310,14 @@
                                             "type": "object",
                                             "properties": {
                                               "id": {
-                                                "type": "number"
+                                                "oneOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "number"
+                                                  }
+                                                ]
                                               },
                                               "documentId": {
                                                 "type": "string"
@@ -9515,7 +10344,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -9526,7 +10362,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -9542,7 +10385,14 @@
                                       "type": "object",
                                       "properties": {
                                         "id": {
-                                          "type": "number"
+                                          "oneOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            }
+                                          ]
                                         },
                                         "documentId": {
                                           "type": "string"
@@ -9575,7 +10425,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -9586,7 +10443,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -9602,7 +10466,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -9616,7 +10487,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -9632,7 +10510,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -9662,7 +10547,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -9673,7 +10565,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -9689,7 +10588,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -9718,7 +10624,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -9729,7 +10642,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -9745,7 +10665,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -9761,7 +10688,14 @@
               "type": "object",
               "properties": {
                 "id": {
-                  "type": "number"
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
                 },
                 "documentId": {
                   "type": "string"
@@ -9775,6 +10709,7 @@
                 "caption": {
                   "type": "string"
                 },
+                "focalPoint": {},
                 "width": {
                   "type": "integer"
                 },
@@ -9811,7 +10746,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -9823,7 +10765,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -9849,7 +10798,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -9860,7 +10816,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -9876,7 +10839,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -9891,7 +10861,14 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "documentId": {
                 "type": "string"
@@ -9905,6 +10882,7 @@
               "caption": {
                 "type": "string"
               },
+              "focalPoint": {},
               "width": {
                 "type": "integer"
               },
@@ -9941,7 +10919,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -9953,7 +10938,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -9979,7 +10971,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -9990,7 +10989,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -10006,7 +11012,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -10035,7 +11048,14 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "documentId": {
                 "type": "string"
@@ -10080,7 +11100,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -10124,6 +11151,18 @@
                     "promidata_hash": {
                       "type": "string"
                     },
+                    "ean": {
+                      "type": "string"
+                    },
+                    "minimum_order_quantity": {
+                      "type": "integer"
+                    },
+                    "quantity_increments": {
+                      "type": "integer"
+                    },
+                    "price_region": {
+                      "type": "string"
+                    },
                     "battery_information": {
                       "type": "string"
                     },
@@ -10132,7 +11171,6 @@
                     },
                     "name": {},
                     "description": {},
-                    "model_name": {},
                     "short_description": {},
                     "material": {},
                     "customization": {},
@@ -10170,7 +11208,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -10184,6 +11229,7 @@
                         "caption": {
                           "type": "string"
                         },
+                        "focalPoint": {},
                         "width": {
                           "type": "integer"
                         },
@@ -10220,7 +11266,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -10232,7 +11285,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -10258,7 +11318,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -10269,7 +11336,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -10285,7 +11359,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -10301,7 +11382,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -10315,6 +11403,7 @@
                           "caption": {
                             "type": "string"
                           },
+                          "focalPoint": {},
                           "width": {
                             "type": "integer"
                           },
@@ -10351,7 +11440,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -10363,7 +11459,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -10389,7 +11492,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -10400,7 +11510,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -10416,7 +11533,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -10431,7 +11555,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -10445,6 +11576,7 @@
                         "caption": {
                           "type": "string"
                         },
+                        "focalPoint": {},
                         "width": {
                           "type": "integer"
                         },
@@ -10481,7 +11613,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -10493,7 +11632,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -10519,7 +11665,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -10530,7 +11683,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -10546,7 +11706,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -10575,7 +11742,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -10588,7 +11762,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -10601,7 +11782,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -10614,7 +11802,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -10631,7 +11826,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -10655,7 +11857,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -10666,7 +11875,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -10682,7 +11898,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -10699,7 +11922,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -10723,7 +11953,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -10737,6 +11974,7 @@
                               "caption": {
                                 "type": "string"
                               },
+                              "focalPoint": {},
                               "width": {
                                 "type": "integer"
                               },
@@ -10773,7 +12011,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -10785,7 +12030,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -10811,7 +12063,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -10822,7 +12081,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -10838,7 +12104,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -10854,7 +12127,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -10868,6 +12148,7 @@
                                 "caption": {
                                   "type": "string"
                                 },
+                                "focalPoint": {},
                                 "width": {
                                   "type": "integer"
                                 },
@@ -10904,7 +12185,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -10916,7 +12204,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -10942,7 +12237,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -10953,7 +12255,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -10969,7 +12278,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -10986,7 +12302,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -11000,6 +12323,7 @@
                                 "caption": {
                                   "type": "string"
                                 },
+                                "focalPoint": {},
                                 "width": {
                                   "type": "integer"
                                 },
@@ -11036,7 +12360,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -11048,7 +12379,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -11074,7 +12412,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -11085,7 +12430,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -11101,7 +12453,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -11173,7 +12532,6 @@
                           "usb_item": {
                             "type": "boolean"
                           },
-                          "embroidery_sizes": {},
                           "is_service_base": {
                             "type": "boolean"
                           },
@@ -11184,7 +12542,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -11207,7 +12572,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -11218,7 +12590,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -11234,7 +12613,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -11268,7 +12654,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -11279,7 +12672,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -11295,7 +12695,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -11310,7 +12717,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -11319,7 +12733,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -11376,7 +12797,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -11387,7 +12815,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -11403,7 +12838,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -11429,7 +12871,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -11440,7 +12889,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -11456,7 +12912,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -11472,7 +12935,14 @@
               "type": "object",
               "properties": {
                 "id": {
-                  "type": "number"
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
                 },
                 "documentId": {
                   "type": "string"
@@ -11486,7 +12956,14 @@
               "type": "object",
               "properties": {
                 "id": {
-                  "type": "number"
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
                 },
                 "documentId": {
                   "type": "string"
@@ -11517,7 +12994,14 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "documentId": {
                 "type": "string"
@@ -11528,7 +13012,14 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "documentId": {
                 "type": "string"
@@ -11544,7 +13035,14 @@
               "type": "object",
               "properties": {
                 "id": {
-                  "type": "number"
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
                 },
                 "documentId": {
                   "type": "string"
@@ -11692,7 +13190,6 @@
               "usb_item": {
                 "type": "boolean"
               },
-              "embroidery_sizes": {},
               "is_service_base": {
                 "type": "boolean"
               },
@@ -11773,7 +13270,14 @@
         ],
         "properties": {
           "id": {
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "documentId": {
             "type": "string"
@@ -11797,7 +13301,14 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "documentId": {
                 "type": "string"
@@ -11811,6 +13322,7 @@
               "caption": {
                 "type": "string"
               },
+              "focalPoint": {},
               "width": {
                 "type": "integer"
               },
@@ -11847,7 +13359,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -11859,7 +13378,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -11874,7 +13400,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -11887,7 +13420,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -11901,7 +13441,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -11915,6 +13462,7 @@
                         "caption": {
                           "type": "string"
                         },
+                        "focalPoint": {},
                         "width": {
                           "type": "integer"
                         },
@@ -11951,7 +13499,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -11963,7 +13518,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -11989,7 +13551,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -12022,7 +13591,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -12042,7 +13618,14 @@
                                       "type": "object",
                                       "properties": {
                                         "id": {
-                                          "type": "number"
+                                          "oneOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            }
+                                          ]
                                         },
                                         "documentId": {
                                           "type": "string"
@@ -12056,7 +13639,14 @@
                                       "type": "object",
                                       "properties": {
                                         "id": {
-                                          "type": "number"
+                                          "oneOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            }
+                                          ]
                                         },
                                         "documentId": {
                                           "type": "string"
@@ -12074,7 +13664,14 @@
                                           "type": "object",
                                           "properties": {
                                             "id": {
-                                              "type": "number"
+                                              "oneOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "number"
+                                                }
+                                              ]
                                             },
                                             "documentId": {
                                               "type": "string"
@@ -12097,7 +13694,14 @@
                                           "type": "object",
                                           "properties": {
                                             "id": {
-                                              "type": "number"
+                                              "oneOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "number"
+                                                }
+                                              ]
                                             },
                                             "documentId": {
                                               "type": "string"
@@ -12108,7 +13712,14 @@
                                           "type": "object",
                                           "properties": {
                                             "id": {
-                                              "type": "number"
+                                              "oneOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "number"
+                                                }
+                                              ]
                                             },
                                             "documentId": {
                                               "type": "string"
@@ -12124,7 +13735,14 @@
                                             "type": "object",
                                             "properties": {
                                               "id": {
-                                                "type": "number"
+                                                "oneOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "number"
+                                                  }
+                                                ]
                                               },
                                               "documentId": {
                                                 "type": "string"
@@ -12151,7 +13769,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -12162,7 +13787,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -12178,7 +13810,14 @@
                                       "type": "object",
                                       "properties": {
                                         "id": {
-                                          "type": "number"
+                                          "oneOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            }
+                                          ]
                                         },
                                         "documentId": {
                                           "type": "string"
@@ -12211,7 +13850,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -12222,7 +13868,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -12238,7 +13891,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -12252,7 +13912,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -12268,7 +13935,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -12298,7 +13972,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -12309,7 +13990,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -12325,7 +14013,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -12354,7 +14049,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -12365,7 +14067,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -12381,7 +14090,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -12397,7 +14113,14 @@
               "type": "object",
               "properties": {
                 "id": {
-                  "type": "number"
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
                 },
                 "documentId": {
                   "type": "string"
@@ -12411,6 +14134,7 @@
                 "caption": {
                   "type": "string"
                 },
+                "focalPoint": {},
                 "width": {
                   "type": "integer"
                 },
@@ -12447,7 +14171,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -12459,7 +14190,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -12485,7 +14223,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -12496,7 +14241,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -12512,7 +14264,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -12529,7 +14288,14 @@
               "type": "object",
               "properties": {
                 "id": {
-                  "type": "number"
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
                 },
                 "documentId": {
                   "type": "string"
@@ -12543,6 +14309,7 @@
                 "caption": {
                   "type": "string"
                 },
+                "focalPoint": {},
                 "width": {
                   "type": "integer"
                 },
@@ -12579,7 +14346,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -12591,7 +14365,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -12617,7 +14398,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -12628,7 +14416,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -12644,7 +14439,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -12716,7 +14518,6 @@
           "usb_item": {
             "type": "boolean"
           },
-          "embroidery_sizes": {},
           "is_service_base": {
             "type": "boolean"
           },
@@ -12727,7 +14528,14 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "documentId": {
                 "type": "string"
@@ -12771,6 +14579,18 @@
               "promidata_hash": {
                 "type": "string"
               },
+              "ean": {
+                "type": "string"
+              },
+              "minimum_order_quantity": {
+                "type": "integer"
+              },
+              "quantity_increments": {
+                "type": "integer"
+              },
+              "price_region": {
+                "type": "string"
+              },
               "battery_information": {
                 "type": "string"
               },
@@ -12779,7 +14599,6 @@
               },
               "name": {},
               "description": {},
-              "model_name": {},
               "short_description": {},
               "material": {},
               "customization": {},
@@ -12817,7 +14636,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -12831,6 +14657,7 @@
                   "caption": {
                     "type": "string"
                   },
+                  "focalPoint": {},
                   "width": {
                     "type": "integer"
                   },
@@ -12867,7 +14694,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -12879,7 +14713,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -12905,7 +14746,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -12916,7 +14764,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -12932,7 +14787,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -12948,7 +14810,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -12962,6 +14831,7 @@
                     "caption": {
                       "type": "string"
                     },
+                    "focalPoint": {},
                     "width": {
                       "type": "integer"
                     },
@@ -12998,7 +14868,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -13010,7 +14887,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -13036,7 +14920,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -13047,7 +14938,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -13063,7 +14961,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -13078,7 +14983,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -13092,6 +15004,7 @@
                   "caption": {
                     "type": "string"
                   },
+                  "focalPoint": {},
                   "width": {
                     "type": "integer"
                   },
@@ -13128,7 +15041,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -13140,7 +15060,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -13166,7 +15093,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -13177,7 +15111,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -13193,7 +15134,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -13222,7 +15170,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -13267,7 +15222,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -13279,7 +15241,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -13288,7 +15257,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -13345,7 +15321,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -13356,7 +15339,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -13372,7 +15362,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -13398,7 +15395,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -13409,7 +15413,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -13425,7 +15436,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -13441,7 +15459,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -13454,7 +15479,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -13467,7 +15499,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -13484,7 +15523,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -13508,7 +15554,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -13519,7 +15572,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -13535,7 +15595,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -13552,7 +15619,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -13576,7 +15650,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -13590,6 +15671,7 @@
                         "caption": {
                           "type": "string"
                         },
+                        "focalPoint": {},
                         "width": {
                           "type": "integer"
                         },
@@ -13626,7 +15708,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -13638,7 +15727,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -13664,7 +15760,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -13675,7 +15778,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -13691,7 +15801,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -13707,7 +15824,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -13721,6 +15845,7 @@
                           "caption": {
                             "type": "string"
                           },
+                          "focalPoint": {},
                           "width": {
                             "type": "integer"
                           },
@@ -13757,7 +15882,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -13769,7 +15901,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -13795,7 +15934,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -13806,7 +15952,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -13822,7 +15975,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -13839,7 +15999,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -13853,6 +16020,7 @@
                           "caption": {
                             "type": "string"
                           },
+                          "focalPoint": {},
                           "width": {
                             "type": "integer"
                           },
@@ -13889,7 +16057,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -13901,7 +16076,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -13927,7 +16109,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -13938,7 +16127,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -13954,7 +16150,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -14026,7 +16229,6 @@
                     "usb_item": {
                       "type": "boolean"
                     },
-                    "embroidery_sizes": {},
                     "is_service_base": {
                       "type": "boolean"
                     },
@@ -14037,7 +16239,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -14060,7 +16269,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -14071,7 +16287,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -14087,7 +16310,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -14121,7 +16351,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -14132,7 +16369,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -14148,7 +16392,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -14174,7 +16425,14 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "documentId": {
                 "type": "string"
@@ -14185,7 +16443,14 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "documentId": {
                 "type": "string"
@@ -14201,7 +16466,14 @@
               "type": "object",
               "properties": {
                 "id": {
-                  "type": "number"
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
                 },
                 "documentId": {
                   "type": "string"
@@ -14273,7 +16545,14 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "documentId": {
             "type": "string"
@@ -14311,7 +16590,14 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "documentId": {
                 "type": "string"
@@ -14344,7 +16630,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -14364,7 +16657,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -14378,7 +16678,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -14396,7 +16703,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -14419,7 +16733,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -14430,7 +16751,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -14446,7 +16774,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -14473,7 +16808,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -14484,7 +16826,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -14500,7 +16849,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -14533,7 +16889,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -14544,7 +16907,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -14560,7 +16930,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -14574,7 +16951,14 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "documentId": {
                 "type": "string"
@@ -14590,7 +16974,14 @@
               "type": "object",
               "properties": {
                 "id": {
-                  "type": "number"
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
                 },
                 "documentId": {
                   "type": "string"
@@ -14628,7 +17019,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -14639,7 +17037,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -14655,7 +17060,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -14713,7 +17125,14 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "documentId": {
             "type": "string"
@@ -14734,7 +17153,14 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "documentId": {
                 "type": "string"
@@ -14767,7 +17193,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -14787,7 +17220,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -14801,7 +17241,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -14819,7 +17266,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -14842,7 +17296,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -14853,7 +17314,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -14869,7 +17337,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -14896,7 +17371,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -14907,7 +17389,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -14923,7 +17412,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -14956,7 +17452,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -14967,7 +17470,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -14983,7 +17493,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -14997,7 +17514,14 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "documentId": {
                 "type": "string"
@@ -15013,7 +17537,14 @@
               "type": "object",
               "properties": {
                 "id": {
-                  "type": "number"
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
                 },
                 "documentId": {
                   "type": "string"
@@ -15034,7 +17565,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -15045,7 +17583,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -15061,7 +17606,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -15221,7 +17773,14 @@
         ],
         "properties": {
           "id": {
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "documentId": {
             "type": "string"
@@ -15266,7 +17825,14 @@
               "type": "object",
               "properties": {
                 "id": {
-                  "type": "number"
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
                 },
                 "documentId": {
                   "type": "string"
@@ -15310,6 +17876,18 @@
                 "promidata_hash": {
                   "type": "string"
                 },
+                "ean": {
+                  "type": "string"
+                },
+                "minimum_order_quantity": {
+                  "type": "integer"
+                },
+                "quantity_increments": {
+                  "type": "integer"
+                },
+                "price_region": {
+                  "type": "string"
+                },
                 "battery_information": {
                   "type": "string"
                 },
@@ -15318,7 +17896,6 @@
                 },
                 "name": {},
                 "description": {},
-                "model_name": {},
                 "short_description": {},
                 "material": {},
                 "customization": {},
@@ -15356,7 +17933,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -15370,6 +17954,7 @@
                     "caption": {
                       "type": "string"
                     },
+                    "focalPoint": {},
                     "width": {
                       "type": "integer"
                     },
@@ -15406,7 +17991,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -15418,7 +18010,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -15433,7 +18032,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -15446,7 +18052,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -15460,7 +18073,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -15474,6 +18094,7 @@
                               "caption": {
                                 "type": "string"
                               },
+                              "focalPoint": {},
                               "width": {
                                 "type": "integer"
                               },
@@ -15510,7 +18131,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -15522,7 +18150,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -15548,7 +18183,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -15581,7 +18223,14 @@
                                       "type": "object",
                                       "properties": {
                                         "id": {
-                                          "type": "number"
+                                          "oneOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            }
+                                          ]
                                         },
                                         "documentId": {
                                           "type": "string"
@@ -15601,7 +18250,14 @@
                                             "type": "object",
                                             "properties": {
                                               "id": {
-                                                "type": "number"
+                                                "oneOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "number"
+                                                  }
+                                                ]
                                               },
                                               "documentId": {
                                                 "type": "string"
@@ -15615,7 +18271,14 @@
                                             "type": "object",
                                             "properties": {
                                               "id": {
-                                                "type": "number"
+                                                "oneOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "number"
+                                                  }
+                                                ]
                                               },
                                               "documentId": {
                                                 "type": "string"
@@ -15633,7 +18296,14 @@
                                                 "type": "object",
                                                 "properties": {
                                                   "id": {
-                                                    "type": "number"
+                                                    "oneOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      }
+                                                    ]
                                                   },
                                                   "documentId": {
                                                     "type": "string"
@@ -15656,7 +18326,14 @@
                                                 "type": "object",
                                                 "properties": {
                                                   "id": {
-                                                    "type": "number"
+                                                    "oneOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      }
+                                                    ]
                                                   },
                                                   "documentId": {
                                                     "type": "string"
@@ -15667,7 +18344,14 @@
                                                 "type": "object",
                                                 "properties": {
                                                   "id": {
-                                                    "type": "number"
+                                                    "oneOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      }
+                                                    ]
                                                   },
                                                   "documentId": {
                                                     "type": "string"
@@ -15683,7 +18367,14 @@
                                                   "type": "object",
                                                   "properties": {
                                                     "id": {
-                                                      "type": "number"
+                                                      "oneOf": [
+                                                        {
+                                                          "type": "string"
+                                                        },
+                                                        {
+                                                          "type": "number"
+                                                        }
+                                                      ]
                                                     },
                                                     "documentId": {
                                                       "type": "string"
@@ -15710,7 +18401,14 @@
                                           "type": "object",
                                           "properties": {
                                             "id": {
-                                              "type": "number"
+                                              "oneOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "number"
+                                                }
+                                              ]
                                             },
                                             "documentId": {
                                               "type": "string"
@@ -15721,7 +18419,14 @@
                                           "type": "object",
                                           "properties": {
                                             "id": {
-                                              "type": "number"
+                                              "oneOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "number"
+                                                }
+                                              ]
                                             },
                                             "documentId": {
                                               "type": "string"
@@ -15737,7 +18442,14 @@
                                             "type": "object",
                                             "properties": {
                                               "id": {
-                                                "type": "number"
+                                                "oneOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "number"
+                                                  }
+                                                ]
                                               },
                                               "documentId": {
                                                 "type": "string"
@@ -15770,7 +18482,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -15781,7 +18500,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -15797,7 +18523,14 @@
                                       "type": "object",
                                       "properties": {
                                         "id": {
-                                          "type": "number"
+                                          "oneOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            }
+                                          ]
                                         },
                                         "documentId": {
                                           "type": "string"
@@ -15811,7 +18544,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -15827,7 +18567,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -15857,7 +18604,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -15868,7 +18622,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -15884,7 +18645,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -15913,7 +18681,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -15924,7 +18699,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -15940,7 +18722,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -15956,7 +18745,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -15970,6 +18766,7 @@
                       "caption": {
                         "type": "string"
                       },
+                      "focalPoint": {},
                       "width": {
                         "type": "integer"
                       },
@@ -16006,7 +18803,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -16018,7 +18822,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -16044,7 +18855,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -16055,7 +18873,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -16071,7 +18896,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -16086,7 +18918,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -16100,6 +18939,7 @@
                     "caption": {
                       "type": "string"
                     },
+                    "focalPoint": {},
                     "width": {
                       "type": "integer"
                     },
@@ -16136,7 +18976,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -16148,7 +18995,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -16174,7 +19028,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -16185,7 +19046,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -16201,7 +19069,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -16230,7 +19105,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -16275,7 +19157,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -16287,7 +19176,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -16296,7 +19192,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -16353,7 +19256,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -16364,7 +19274,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -16380,7 +19297,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -16406,7 +19330,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -16417,7 +19348,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -16433,7 +19371,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -16449,7 +19394,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -16462,7 +19414,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -16475,7 +19434,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -16492,7 +19458,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -16516,7 +19489,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -16527,7 +19507,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -16543,7 +19530,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -16560,7 +19554,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -16584,7 +19585,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -16598,6 +19606,7 @@
                           "caption": {
                             "type": "string"
                           },
+                          "focalPoint": {},
                           "width": {
                             "type": "integer"
                           },
@@ -16634,7 +19643,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -16646,7 +19662,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -16672,7 +19695,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -16683,7 +19713,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -16699,7 +19736,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -16715,7 +19759,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -16729,6 +19780,7 @@
                             "caption": {
                               "type": "string"
                             },
+                            "focalPoint": {},
                             "width": {
                               "type": "integer"
                             },
@@ -16765,7 +19817,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -16777,7 +19836,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -16803,7 +19869,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -16814,7 +19887,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -16830,7 +19910,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -16847,7 +19934,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -16861,6 +19955,7 @@
                             "caption": {
                               "type": "string"
                             },
+                            "focalPoint": {},
                             "width": {
                               "type": "integer"
                             },
@@ -16897,7 +19992,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -16909,7 +20011,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -16935,7 +20044,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -16946,7 +20062,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -16962,7 +20085,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -17034,7 +20164,6 @@
                       "usb_item": {
                         "type": "boolean"
                       },
-                      "embroidery_sizes": {},
                       "is_service_base": {
                         "type": "boolean"
                       },
@@ -17045,7 +20174,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -17068,7 +20204,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -17079,7 +20222,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -17095,7 +20245,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -17129,7 +20286,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -17140,7 +20304,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -17156,7 +20327,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -17171,7 +20349,14 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "documentId": {
                 "type": "string"
@@ -17194,7 +20379,14 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "documentId": {
                 "type": "string"
@@ -17205,7 +20397,14 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "documentId": {
                 "type": "string"
@@ -17221,7 +20420,14 @@
               "type": "object",
               "properties": {
                 "id": {
-                  "type": "number"
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
                 },
                 "documentId": {
                   "type": "string"
@@ -17356,7 +20562,14 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "documentId": {
             "type": "string"
@@ -17365,7 +20578,14 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "documentId": {
                 "type": "string"
@@ -17410,7 +20630,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -17454,6 +20681,18 @@
                     "promidata_hash": {
                       "type": "string"
                     },
+                    "ean": {
+                      "type": "string"
+                    },
+                    "minimum_order_quantity": {
+                      "type": "integer"
+                    },
+                    "quantity_increments": {
+                      "type": "integer"
+                    },
+                    "price_region": {
+                      "type": "string"
+                    },
                     "battery_information": {
                       "type": "string"
                     },
@@ -17462,7 +20701,6 @@
                     },
                     "name": {},
                     "description": {},
-                    "model_name": {},
                     "short_description": {},
                     "material": {},
                     "customization": {},
@@ -17500,7 +20738,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -17514,6 +20759,7 @@
                         "caption": {
                           "type": "string"
                         },
+                        "focalPoint": {},
                         "width": {
                           "type": "integer"
                         },
@@ -17550,7 +20796,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -17562,7 +20815,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -17577,7 +20837,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -17590,7 +20857,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -17604,7 +20878,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -17618,6 +20899,7 @@
                                   "caption": {
                                     "type": "string"
                                   },
+                                  "focalPoint": {},
                                   "width": {
                                     "type": "integer"
                                   },
@@ -17654,7 +20936,14 @@
                                       "type": "object",
                                       "properties": {
                                         "id": {
-                                          "type": "number"
+                                          "oneOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            }
+                                          ]
                                         },
                                         "documentId": {
                                           "type": "string"
@@ -17666,7 +20955,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -17692,7 +20988,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -17725,7 +21028,14 @@
                                           "type": "object",
                                           "properties": {
                                             "id": {
-                                              "type": "number"
+                                              "oneOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "number"
+                                                }
+                                              ]
                                             },
                                             "documentId": {
                                               "type": "string"
@@ -17745,7 +21055,14 @@
                                                 "type": "object",
                                                 "properties": {
                                                   "id": {
-                                                    "type": "number"
+                                                    "oneOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      }
+                                                    ]
                                                   },
                                                   "documentId": {
                                                     "type": "string"
@@ -17759,7 +21076,14 @@
                                                 "type": "object",
                                                 "properties": {
                                                   "id": {
-                                                    "type": "number"
+                                                    "oneOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      }
+                                                    ]
                                                   },
                                                   "documentId": {
                                                     "type": "string"
@@ -17777,7 +21101,14 @@
                                                     "type": "object",
                                                     "properties": {
                                                       "id": {
-                                                        "type": "number"
+                                                        "oneOf": [
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "number"
+                                                          }
+                                                        ]
                                                       },
                                                       "documentId": {
                                                         "type": "string"
@@ -17800,7 +21131,14 @@
                                                     "type": "object",
                                                     "properties": {
                                                       "id": {
-                                                        "type": "number"
+                                                        "oneOf": [
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "number"
+                                                          }
+                                                        ]
                                                       },
                                                       "documentId": {
                                                         "type": "string"
@@ -17811,7 +21149,14 @@
                                                     "type": "object",
                                                     "properties": {
                                                       "id": {
-                                                        "type": "number"
+                                                        "oneOf": [
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "number"
+                                                          }
+                                                        ]
                                                       },
                                                       "documentId": {
                                                         "type": "string"
@@ -17827,7 +21172,14 @@
                                                       "type": "object",
                                                       "properties": {
                                                         "id": {
-                                                          "type": "number"
+                                                          "oneOf": [
+                                                            {
+                                                              "type": "string"
+                                                            },
+                                                            {
+                                                              "type": "number"
+                                                            }
+                                                          ]
                                                         },
                                                         "documentId": {
                                                           "type": "string"
@@ -17854,7 +21206,14 @@
                                               "type": "object",
                                               "properties": {
                                                 "id": {
-                                                  "type": "number"
+                                                  "oneOf": [
+                                                    {
+                                                      "type": "string"
+                                                    },
+                                                    {
+                                                      "type": "number"
+                                                    }
+                                                  ]
                                                 },
                                                 "documentId": {
                                                   "type": "string"
@@ -17865,7 +21224,14 @@
                                               "type": "object",
                                               "properties": {
                                                 "id": {
-                                                  "type": "number"
+                                                  "oneOf": [
+                                                    {
+                                                      "type": "string"
+                                                    },
+                                                    {
+                                                      "type": "number"
+                                                    }
+                                                  ]
                                                 },
                                                 "documentId": {
                                                   "type": "string"
@@ -17881,7 +21247,14 @@
                                                 "type": "object",
                                                 "properties": {
                                                   "id": {
-                                                    "type": "number"
+                                                    "oneOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      }
+                                                    ]
                                                   },
                                                   "documentId": {
                                                     "type": "string"
@@ -17914,7 +21287,14 @@
                                         "type": "object",
                                         "properties": {
                                           "id": {
-                                            "type": "number"
+                                            "oneOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "number"
+                                              }
+                                            ]
                                           },
                                           "documentId": {
                                             "type": "string"
@@ -17925,7 +21305,14 @@
                                         "type": "object",
                                         "properties": {
                                           "id": {
-                                            "type": "number"
+                                            "oneOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "number"
+                                              }
+                                            ]
                                           },
                                           "documentId": {
                                             "type": "string"
@@ -17941,7 +21328,14 @@
                                           "type": "object",
                                           "properties": {
                                             "id": {
-                                              "type": "number"
+                                              "oneOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "number"
+                                                }
+                                              ]
                                             },
                                             "documentId": {
                                               "type": "string"
@@ -17955,7 +21349,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -17971,7 +21372,14 @@
                                       "type": "object",
                                       "properties": {
                                         "id": {
-                                          "type": "number"
+                                          "oneOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            }
+                                          ]
                                         },
                                         "documentId": {
                                           "type": "string"
@@ -18001,7 +21409,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -18012,7 +21427,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -18028,7 +21450,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -18057,7 +21486,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -18068,7 +21504,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -18084,7 +21527,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -18100,7 +21550,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -18114,6 +21571,7 @@
                           "caption": {
                             "type": "string"
                           },
+                          "focalPoint": {},
                           "width": {
                             "type": "integer"
                           },
@@ -18150,7 +21608,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -18162,7 +21627,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -18188,7 +21660,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -18199,7 +21678,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -18215,7 +21701,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -18230,7 +21723,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -18244,6 +21744,7 @@
                         "caption": {
                           "type": "string"
                         },
+                        "focalPoint": {},
                         "width": {
                           "type": "integer"
                         },
@@ -18280,7 +21781,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -18292,7 +21800,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -18318,7 +21833,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -18329,7 +21851,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -18345,7 +21874,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -18374,7 +21910,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -18387,7 +21930,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -18400,7 +21950,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -18413,7 +21970,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -18430,7 +21994,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -18454,7 +22025,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -18465,7 +22043,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -18481,7 +22066,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -18498,7 +22090,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -18522,7 +22121,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -18536,6 +22142,7 @@
                               "caption": {
                                 "type": "string"
                               },
+                              "focalPoint": {},
                               "width": {
                                 "type": "integer"
                               },
@@ -18572,7 +22179,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -18584,7 +22198,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -18610,7 +22231,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -18621,7 +22249,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -18637,7 +22272,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -18653,7 +22295,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -18667,6 +22316,7 @@
                                 "caption": {
                                   "type": "string"
                                 },
+                                "focalPoint": {},
                                 "width": {
                                   "type": "integer"
                                 },
@@ -18703,7 +22353,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -18715,7 +22372,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -18741,7 +22405,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -18752,7 +22423,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -18768,7 +22446,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -18785,7 +22470,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -18799,6 +22491,7 @@
                                 "caption": {
                                   "type": "string"
                                 },
+                                "focalPoint": {},
                                 "width": {
                                   "type": "integer"
                                 },
@@ -18835,7 +22528,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -18847,7 +22547,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -18873,7 +22580,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -18884,7 +22598,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -18900,7 +22621,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -18972,7 +22700,6 @@
                           "usb_item": {
                             "type": "boolean"
                           },
-                          "embroidery_sizes": {},
                           "is_service_base": {
                             "type": "boolean"
                           },
@@ -18983,7 +22710,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -19006,7 +22740,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -19017,7 +22758,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -19033,7 +22781,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -19067,7 +22822,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -19078,7 +22840,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -19094,7 +22863,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -19109,7 +22885,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -19118,7 +22901,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -19175,7 +22965,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -19186,7 +22983,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -19202,7 +23006,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -19228,7 +23039,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -19239,7 +23057,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -19255,7 +23080,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -19315,7 +23147,14 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "documentId": {
                 "type": "string"
@@ -19326,7 +23165,14 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "documentId": {
                 "type": "string"
@@ -19342,7 +23188,14 @@
               "type": "object",
               "properties": {
                 "id": {
-                  "type": "number"
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
                 },
                 "documentId": {
                   "type": "string"
@@ -19406,7 +23259,14 @@
         ],
         "properties": {
           "id": {
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "documentId": {
             "type": "string"
@@ -19418,7 +23278,14 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "documentId": {
                 "type": "string"
@@ -19463,7 +23330,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -19507,6 +23381,18 @@
                     "promidata_hash": {
                       "type": "string"
                     },
+                    "ean": {
+                      "type": "string"
+                    },
+                    "minimum_order_quantity": {
+                      "type": "integer"
+                    },
+                    "quantity_increments": {
+                      "type": "integer"
+                    },
+                    "price_region": {
+                      "type": "string"
+                    },
                     "battery_information": {
                       "type": "string"
                     },
@@ -19515,7 +23401,6 @@
                     },
                     "name": {},
                     "description": {},
-                    "model_name": {},
                     "short_description": {},
                     "material": {},
                     "customization": {},
@@ -19553,7 +23438,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -19567,6 +23459,7 @@
                         "caption": {
                           "type": "string"
                         },
+                        "focalPoint": {},
                         "width": {
                           "type": "integer"
                         },
@@ -19603,7 +23496,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -19615,7 +23515,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -19630,7 +23537,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -19643,7 +23557,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -19657,7 +23578,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -19671,6 +23599,7 @@
                                   "caption": {
                                     "type": "string"
                                   },
+                                  "focalPoint": {},
                                   "width": {
                                     "type": "integer"
                                   },
@@ -19707,7 +23636,14 @@
                                       "type": "object",
                                       "properties": {
                                         "id": {
-                                          "type": "number"
+                                          "oneOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            }
+                                          ]
                                         },
                                         "documentId": {
                                           "type": "string"
@@ -19719,7 +23655,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -19745,7 +23688,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -19778,7 +23728,14 @@
                                           "type": "object",
                                           "properties": {
                                             "id": {
-                                              "type": "number"
+                                              "oneOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "number"
+                                                }
+                                              ]
                                             },
                                             "documentId": {
                                               "type": "string"
@@ -19798,7 +23755,14 @@
                                                 "type": "object",
                                                 "properties": {
                                                   "id": {
-                                                    "type": "number"
+                                                    "oneOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      }
+                                                    ]
                                                   },
                                                   "documentId": {
                                                     "type": "string"
@@ -19812,7 +23776,14 @@
                                                 "type": "object",
                                                 "properties": {
                                                   "id": {
-                                                    "type": "number"
+                                                    "oneOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      }
+                                                    ]
                                                   },
                                                   "documentId": {
                                                     "type": "string"
@@ -19830,7 +23801,14 @@
                                                     "type": "object",
                                                     "properties": {
                                                       "id": {
-                                                        "type": "number"
+                                                        "oneOf": [
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "number"
+                                                          }
+                                                        ]
                                                       },
                                                       "documentId": {
                                                         "type": "string"
@@ -19853,7 +23831,14 @@
                                                     "type": "object",
                                                     "properties": {
                                                       "id": {
-                                                        "type": "number"
+                                                        "oneOf": [
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "number"
+                                                          }
+                                                        ]
                                                       },
                                                       "documentId": {
                                                         "type": "string"
@@ -19864,7 +23849,14 @@
                                                     "type": "object",
                                                     "properties": {
                                                       "id": {
-                                                        "type": "number"
+                                                        "oneOf": [
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "number"
+                                                          }
+                                                        ]
                                                       },
                                                       "documentId": {
                                                         "type": "string"
@@ -19880,7 +23872,14 @@
                                                       "type": "object",
                                                       "properties": {
                                                         "id": {
-                                                          "type": "number"
+                                                          "oneOf": [
+                                                            {
+                                                              "type": "string"
+                                                            },
+                                                            {
+                                                              "type": "number"
+                                                            }
+                                                          ]
                                                         },
                                                         "documentId": {
                                                           "type": "string"
@@ -19907,7 +23906,14 @@
                                               "type": "object",
                                               "properties": {
                                                 "id": {
-                                                  "type": "number"
+                                                  "oneOf": [
+                                                    {
+                                                      "type": "string"
+                                                    },
+                                                    {
+                                                      "type": "number"
+                                                    }
+                                                  ]
                                                 },
                                                 "documentId": {
                                                   "type": "string"
@@ -19918,7 +23924,14 @@
                                               "type": "object",
                                               "properties": {
                                                 "id": {
-                                                  "type": "number"
+                                                  "oneOf": [
+                                                    {
+                                                      "type": "string"
+                                                    },
+                                                    {
+                                                      "type": "number"
+                                                    }
+                                                  ]
                                                 },
                                                 "documentId": {
                                                   "type": "string"
@@ -19934,7 +23947,14 @@
                                                 "type": "object",
                                                 "properties": {
                                                   "id": {
-                                                    "type": "number"
+                                                    "oneOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      }
+                                                    ]
                                                   },
                                                   "documentId": {
                                                     "type": "string"
@@ -19967,7 +23987,14 @@
                                         "type": "object",
                                         "properties": {
                                           "id": {
-                                            "type": "number"
+                                            "oneOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "number"
+                                              }
+                                            ]
                                           },
                                           "documentId": {
                                             "type": "string"
@@ -19978,7 +24005,14 @@
                                         "type": "object",
                                         "properties": {
                                           "id": {
-                                            "type": "number"
+                                            "oneOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "number"
+                                              }
+                                            ]
                                           },
                                           "documentId": {
                                             "type": "string"
@@ -19994,7 +24028,14 @@
                                           "type": "object",
                                           "properties": {
                                             "id": {
-                                              "type": "number"
+                                              "oneOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "number"
+                                                }
+                                              ]
                                             },
                                             "documentId": {
                                               "type": "string"
@@ -20008,7 +24049,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -20024,7 +24072,14 @@
                                       "type": "object",
                                       "properties": {
                                         "id": {
-                                          "type": "number"
+                                          "oneOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            }
+                                          ]
                                         },
                                         "documentId": {
                                           "type": "string"
@@ -20054,7 +24109,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -20065,7 +24127,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -20081,7 +24150,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -20110,7 +24186,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -20121,7 +24204,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -20137,7 +24227,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -20153,7 +24250,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -20167,6 +24271,7 @@
                           "caption": {
                             "type": "string"
                           },
+                          "focalPoint": {},
                           "width": {
                             "type": "integer"
                           },
@@ -20203,7 +24308,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -20215,7 +24327,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -20241,7 +24360,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -20252,7 +24378,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -20268,7 +24401,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -20283,7 +24423,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -20297,6 +24444,7 @@
                         "caption": {
                           "type": "string"
                         },
+                        "focalPoint": {},
                         "width": {
                           "type": "integer"
                         },
@@ -20333,7 +24481,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -20345,7 +24500,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -20371,7 +24533,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -20382,7 +24551,14 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "number"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
                             },
                             "documentId": {
                               "type": "string"
@@ -20398,7 +24574,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -20427,7 +24610,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -20440,7 +24630,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -20453,7 +24650,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -20466,7 +24670,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -20483,7 +24694,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -20507,7 +24725,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -20518,7 +24743,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -20534,7 +24766,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -20551,7 +24790,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -20575,7 +24821,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -20589,6 +24842,7 @@
                               "caption": {
                                 "type": "string"
                               },
+                              "focalPoint": {},
                               "width": {
                                 "type": "integer"
                               },
@@ -20625,7 +24879,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -20637,7 +24898,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -20663,7 +24931,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -20674,7 +24949,14 @@
                                 "type": "object",
                                 "properties": {
                                   "id": {
-                                    "type": "number"
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
                                   },
                                   "documentId": {
                                     "type": "string"
@@ -20690,7 +24972,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -20706,7 +24995,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -20720,6 +25016,7 @@
                                 "caption": {
                                   "type": "string"
                                 },
+                                "focalPoint": {},
                                 "width": {
                                   "type": "integer"
                                 },
@@ -20756,7 +25053,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -20768,7 +25072,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -20794,7 +25105,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -20805,7 +25123,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -20821,7 +25146,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -20838,7 +25170,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -20852,6 +25191,7 @@
                                 "caption": {
                                   "type": "string"
                                 },
+                                "focalPoint": {},
                                 "width": {
                                   "type": "integer"
                                 },
@@ -20888,7 +25228,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -20900,7 +25247,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -20926,7 +25280,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -20937,7 +25298,14 @@
                                   "type": "object",
                                   "properties": {
                                     "id": {
-                                      "type": "number"
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
                                     },
                                     "documentId": {
                                       "type": "string"
@@ -20953,7 +25321,14 @@
                                     "type": "object",
                                     "properties": {
                                       "id": {
-                                        "type": "number"
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
                                       },
                                       "documentId": {
                                         "type": "string"
@@ -21025,7 +25400,6 @@
                           "usb_item": {
                             "type": "boolean"
                           },
-                          "embroidery_sizes": {},
                           "is_service_base": {
                             "type": "boolean"
                           },
@@ -21036,7 +25410,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -21059,7 +25440,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -21070,7 +25458,14 @@
                             "type": "object",
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
                               },
                               "documentId": {
                                 "type": "string"
@@ -21086,7 +25481,14 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
                                 },
                                 "documentId": {
                                   "type": "string"
@@ -21120,7 +25522,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -21131,7 +25540,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -21147,7 +25563,14 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ]
                           },
                           "documentId": {
                             "type": "string"
@@ -21162,7 +25585,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -21171,7 +25601,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -21228,7 +25665,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -21239,7 +25683,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"
@@ -21255,7 +25706,14 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
                         },
                         "documentId": {
                           "type": "string"
@@ -21281,7 +25739,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -21292,7 +25757,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
                   },
                   "documentId": {
                     "type": "string"
@@ -21308,7 +25780,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -21433,36 +25912,6 @@
           "meilisearch_failed": {
             "type": "integer"
           },
-          "gemini_status": {
-            "type": "string",
-            "enum": [
-              "pending",
-              "running",
-              "completed",
-              "failed",
-              "skipped"
-            ]
-          },
-          "gemini_started_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "gemini_completed_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "gemini_total": {
-            "type": "integer"
-          },
-          "gemini_synced": {
-            "type": "integer"
-          },
-          "gemini_skipped": {
-            "type": "integer"
-          },
-          "gemini_failed": {
-            "type": "integer"
-          },
           "errors": {},
           "last_error": {
             "type": "string"
@@ -21507,7 +25956,14 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "documentId": {
                 "type": "string"
@@ -21518,7 +25974,14 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "number"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               },
               "documentId": {
                 "type": "string"
@@ -21534,7 +25997,14 @@
               "type": "object",
               "properties": {
                 "id": {
-                  "type": "number"
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
                 },
                 "documentId": {
                   "type": "string"
@@ -21546,7 +26016,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -21668,36 +26145,6 @@
                 "meilisearch_failed": {
                   "type": "integer"
                 },
-                "gemini_status": {
-                  "type": "string",
-                  "enum": [
-                    "pending",
-                    "running",
-                    "completed",
-                    "failed",
-                    "skipped"
-                  ]
-                },
-                "gemini_started_at": {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                "gemini_completed_at": {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                "gemini_total": {
-                  "type": "integer"
-                },
-                "gemini_synced": {
-                  "type": "integer"
-                },
-                "gemini_skipped": {
-                  "type": "integer"
-                },
-                "gemini_failed": {
-                  "type": "integer"
-                },
                 "errors": {},
                 "last_error": {
                   "type": "string"
@@ -21742,7 +26189,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -21753,7 +26207,14 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
                     },
                     "documentId": {
                       "type": "string"
@@ -21769,7 +26230,14 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "number"
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
                       },
                       "documentId": {
                         "type": "string"

--- a/backend/types/generated/components.d.ts
+++ b/backend/types/generated/components.d.ts
@@ -7,6 +7,13 @@ export interface ProductDimensions extends Struct.ComponentSchema {
     displayName: 'Dimensions';
   };
   attributes: {
+    depth: Schema.Attribute.Decimal &
+      Schema.Attribute.SetMinMax<
+        {
+          min: 0;
+        },
+        number
+      >;
     diameter: Schema.Attribute.Decimal &
       Schema.Attribute.SetMinMax<
         {

--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -203,6 +203,63 @@ export interface AdminRole extends Struct.CollectionTypeSchema {
   };
 }
 
+export interface AdminSession extends Struct.CollectionTypeSchema {
+  collectionName: 'strapi_sessions';
+  info: {
+    description: 'Session Manager storage';
+    displayName: 'Session';
+    name: 'Session';
+    pluralName: 'sessions';
+    singularName: 'session';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+    i18n: {
+      localized: false;
+    };
+  };
+  attributes: {
+    absoluteExpiresAt: Schema.Attribute.DateTime & Schema.Attribute.Private;
+    childId: Schema.Attribute.String & Schema.Attribute.Private;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    deviceId: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Private;
+    expiresAt: Schema.Attribute.DateTime &
+      Schema.Attribute.Required &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<'oneToMany', 'admin::session'> &
+      Schema.Attribute.Private;
+    origin: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    sessionId: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Private &
+      Schema.Attribute.Unique;
+    status: Schema.Attribute.String & Schema.Attribute.Private;
+    type: Schema.Attribute.String & Schema.Attribute.Private;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    userId: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Private;
+  };
+}
+
 export interface AdminTransferToken extends Struct.CollectionTypeSchema {
   collectionName: 'strapi_transfer_tokens';
   info: {
@@ -435,7 +492,6 @@ export interface ApiProductVariantProductVariant
     dimensions_height: Schema.Attribute.Decimal;
     dimensions_length: Schema.Attribute.Decimal;
     dimensions_width: Schema.Attribute.Decimal;
-    embroidery_sizes: Schema.Attribute.JSON;
     fragile: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
     gallery_images: Schema.Attribute.Media<'images', true>;
     hex_color: Schema.Attribute.String;
@@ -523,6 +579,10 @@ export interface ApiProductProduct extends Struct.CollectionTypeSchema {
       }>;
     description: Schema.Attribute.JSON;
     dimensions: Schema.Attribute.Component<'product.dimensions', false>;
+    ean: Schema.Attribute.String &
+      Schema.Attribute.SetMinMaxLength<{
+        maxLength: 20;
+      }>;
     gallery_images: Schema.Attribute.Media<'images', true>;
     hex_colors: Schema.Attribute.JSON;
     imprint_position: Schema.Attribute.Component<
@@ -540,13 +600,18 @@ export interface ApiProductProduct extends Struct.CollectionTypeSchema {
     main_image: Schema.Attribute.Media<'images'>;
     material: Schema.Attribute.JSON;
     maxcolors: Schema.Attribute.Integer;
+    minimum_order_quantity: Schema.Attribute.Integer &
+      Schema.Attribute.DefaultTo<1>;
     model_image: Schema.Attribute.Media<'images'>;
-    model_name: Schema.Attribute.JSON;
     must_have_imprint: Schema.Attribute.Boolean &
       Schema.Attribute.DefaultTo<false>;
     name: Schema.Attribute.JSON & Schema.Attribute.Required;
     price_max: Schema.Attribute.Decimal;
     price_min: Schema.Attribute.Decimal;
+    price_region: Schema.Attribute.String &
+      Schema.Attribute.SetMinMaxLength<{
+        maxLength: 20;
+      }>;
     price_tiers: Schema.Attribute.Component<'product.price-tier', true>;
     print_option_group: Schema.Attribute.String &
       Schema.Attribute.SetMinMaxLength<{
@@ -555,6 +620,8 @@ export interface ApiProductProduct extends Struct.CollectionTypeSchema {
     product_filters: Schema.Attribute.JSON;
     promidata_hash: Schema.Attribute.String;
     publishedAt: Schema.Attribute.DateTime;
+    quantity_increments: Schema.Attribute.Integer &
+      Schema.Attribute.DefaultTo<1>;
     rag_metadata: Schema.Attribute.JSON & Schema.Attribute.DefaultTo<{}>;
     refining: Schema.Attribute.JSON;
     refining_dimensions: Schema.Attribute.JSON;
@@ -748,7 +815,7 @@ export interface ApiSyncConfigurationSyncConfiguration
 export interface ApiSyncSessionSyncSession extends Struct.CollectionTypeSchema {
   collectionName: 'sync_sessions';
   info: {
-    description: 'Tracks full sync pipeline: Promidata \u2192 Images \u2192 Meilisearch \u2192 Gemini';
+    description: 'Tracks full sync pipeline: Promidata \u2192 Images \u2192 Meilisearch';
     displayName: 'Sync Session';
     pluralName: 'sync-sessions';
     singularName: 'sync-session';
@@ -764,16 +831,6 @@ export interface ApiSyncSessionSyncSession extends Struct.CollectionTypeSchema {
     duration_seconds: Schema.Attribute.Integer;
     error_count: Schema.Attribute.Integer & Schema.Attribute.DefaultTo<0>;
     errors: Schema.Attribute.JSON & Schema.Attribute.DefaultTo<[]>;
-    gemini_completed_at: Schema.Attribute.DateTime;
-    gemini_failed: Schema.Attribute.Integer & Schema.Attribute.DefaultTo<0>;
-    gemini_skipped: Schema.Attribute.Integer & Schema.Attribute.DefaultTo<0>;
-    gemini_started_at: Schema.Attribute.DateTime;
-    gemini_status: Schema.Attribute.Enumeration<
-      ['pending', 'running', 'completed', 'failed', 'skipped']
-    > &
-      Schema.Attribute.DefaultTo<'pending'>;
-    gemini_synced: Schema.Attribute.Integer & Schema.Attribute.DefaultTo<0>;
-    gemini_total: Schema.Attribute.Integer & Schema.Attribute.DefaultTo<0>;
     images_completed_at: Schema.Attribute.DateTime;
     images_deduplicated: Schema.Attribute.Integer &
       Schema.Attribute.DefaultTo<0>;
@@ -1100,12 +1157,13 @@ export interface PluginUploadFile extends Struct.CollectionTypeSchema {
     };
   };
   attributes: {
-    alternativeText: Schema.Attribute.String;
-    caption: Schema.Attribute.String;
+    alternativeText: Schema.Attribute.Text;
+    caption: Schema.Attribute.Text;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
     ext: Schema.Attribute.String;
+    focalPoint: Schema.Attribute.JSON;
     folder: Schema.Attribute.Relation<'manyToOne', 'plugin::upload.folder'> &
       Schema.Attribute.Private;
     folderPath: Schema.Attribute.String &
@@ -1125,7 +1183,7 @@ export interface PluginUploadFile extends Struct.CollectionTypeSchema {
       Schema.Attribute.Private;
     mime: Schema.Attribute.String & Schema.Attribute.Required;
     name: Schema.Attribute.String & Schema.Attribute.Required;
-    previewUrl: Schema.Attribute.String;
+    previewUrl: Schema.Attribute.Text;
     provider: Schema.Attribute.String & Schema.Attribute.Required;
     provider_metadata: Schema.Attribute.JSON;
     publishedAt: Schema.Attribute.DateTime;
@@ -1134,7 +1192,7 @@ export interface PluginUploadFile extends Struct.CollectionTypeSchema {
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
-    url: Schema.Attribute.String & Schema.Attribute.Required;
+    url: Schema.Attribute.Text & Schema.Attribute.Required;
     width: Schema.Attribute.Integer;
   };
 }
@@ -1349,6 +1407,7 @@ declare module '@strapi/strapi' {
       'admin::api-token-permission': AdminApiTokenPermission;
       'admin::permission': AdminPermission;
       'admin::role': AdminRole;
+      'admin::session': AdminSession;
       'admin::transfer-token': AdminTransferToken;
       'admin::transfer-token-permission': AdminTransferTokenPermission;
       'admin::user': AdminUser;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
 
   # Meilisearch
   meilisearch:
-    image: getmeili/meilisearch:latest
+    image: getmeili/meilisearch:v1.41
     container_name: promoatlas-meilisearch
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Summary

Adds hybrid semantic + keyword search to MeiliSearch using OpenAI text-embedding-3-small. MeiliSearch generates embeddings automatically on document add/update — **zero changes to the sync pipeline**.

## How it works

1. **Setup** (once per MeiliSearch instance): `node scripts/setup-meilisearch-embedder.js`
2. **Reindex**: `node scripts/reindex-meilisearch.js` (embeddings generated automatically)
3. **Search**: Add `?semantic=0.5` parameter to enable hybrid mode

| Parameter | Value | Behavior |
|---|---|---|
| `semantic=0` | Pure keyword | Existing behavior (SKU, exact matches) |
| `semantic=0.5` | Balanced | Best for mixed queries |
| `semantic=0.7` | Lean semantic | Best for natural language ("eco-friendly bags for events") |
| `semantic=1.0` | Pure semantic | Concept matching only |
| *(omitted)* | No hybrid | Keyword-only (backwards compatible) |

## Test results (3,270 products, 100% embedded)

| Query | Result | Type |
|---|---|---|
| "eco-friendly bags for a conference" | OEKO-TEX shopping bags | Semantic |
| "something warm to wear in winter" | Knitted scarves, Christmas jumpers | Semantic |
| "A23-100804" | Exact SKU match | Keyword |

## Changes

- `docker-compose.yml` — Pin MeiliSearch to v1.41
- `meilisearch-types.ts` — Add `hybrid` to search options
- `meilisearch.ts` — Pass hybrid params in `searchProducts()`
- `product controller` — Accept `semantic` query parameter
- `setup-meilisearch-embedder.js` — New setup script
- `.env.example` — Add OPENAI_API_KEY, remove Cloudflare AutoRAG leftovers

## Cost

~$0.007 for dev (3,270 products). ~$2 for 1M products. ~$7-10/year total.

## Test plan

- [x] Backend builds (0 TS errors)
- [x] 3,270/3,270 embeddings generated
- [x] Semantic search returns relevant results
- [x] Keyword search still works
- [x] Backwards compatible (no `semantic` param = keyword-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)