### PR TITLE
feat: standalone full-screen AI chatbot page

### DIFF
--- a/backend/src/api/product/services/meilisearch-types.ts
+++ b/backend/src/api/product/services/meilisearch-types.ts
@@ -141,12 +141,6 @@ export interface MeilisearchSearchOptions {
   // Cropping (for long text)
   attributesToCrop?: string[];    // Fields to crop
   cropLength?: number;            // Max length per cropped field
-
-  // Hybrid search (semantic + keyword)
-  hybrid?: {
-    embedder: string;             // Embedder name (e.g., 'product_search')
-    semanticRatio?: number;       // 0.0 = keyword only, 1.0 = semantic only (default: 0.5)
-  };
 }
 
 /**

--- a/frontend/src/app/api/chat-bot/route.ts
+++ b/frontend/src/app/api/chat-bot/route.ts
@@ -1,0 +1,208 @@
+import { streamText, tool, stepCountIs, convertToModelMessages } from "ai";
+import { anthropic } from "@ai-sdk/anthropic";
+import { z } from "zod";
+import { readPrompts } from "@/app/api/admin/prompts/route";
+import { searchStrapi, mapToRichProduct } from "@/lib/chat-search";
+
+export const maxDuration = 30;
+
+// ---------------------------------------------------------------------------
+// Build system prompt for standalone chatbot (no catalog grid context)
+// ---------------------------------------------------------------------------
+
+async function buildSystemPrompt(): Promise<string> {
+  const p = await readPrompts();
+
+  const sections = [
+    p.regularPrompt,
+    p.companyKnowledge ? `\n\n## Company Knowledge\n${p.companyKnowledge}` : "",
+    p.industryKnowledge
+      ? `\n\n## Industry Knowledge\n${p.industryKnowledge}`
+      : "",
+    p.brandVoice ? `\n\n## Brand Voice & Tone\n${p.brandVoice}` : "",
+  ];
+
+  const dynamicPrompt = sections.filter(Boolean).join("");
+
+  return `${dynamicPrompt}
+
+## How This Chat Works
+You are in a standalone chat interface. There is NO product grid or sidebar — products appear as visual cards INLINE in the conversation. When you search for products, the user sees rich product cards directly in your message.
+
+## Tool Usage
+Use the searchProducts tool to find and display products inline. Call it whenever the user asks about products, wants recommendations, or wants to browse.
+
+### How search works
+Our search engine uses HYBRID search: keyword matching + AI semantic understanding.
+- The text query field understands MEANING, not just exact words.
+- Category, brand, color, size, and price filters are EXACT.
+- COMBINE both: filters for structure, text query for intent/meaning.
+
+### Decompose every request into filters + query
+
+FILTERS (exact, structural):
+- category — Product type codes like "TEXTILES/SHIRTS-TOPS/POLO", "OFFICE/BALLPOINT_PENS-ROLLERS"
+- brand — Exact brand name
+- colors — Comma-separated color names
+- sizes — Comma-separated sizes
+- price_min / price_max — EUR values
+- sort — "price_min:asc", "price_min:desc", "updatedAt:desc", "brand:asc"
+
+QUERY (semantic, meaning-based):
+- Materials: "organic cotton", "recycled polyester", "bamboo"
+- Features: "waterproof", "flame-resistant", "quick-dry"
+- Certifications: "GOTS certified", "OEKO-TEX", "Fair Trade"
+- Quality/style: "exclusive", "premium", "budget-friendly"
+- Purpose: "corporate gift", "outdoor event", "trade show"
+
+### Examples
+"polo shirts" → category: "TEXTILES/SHIRTS-TOPS/POLO"
+"sustainable t-shirts" → category: "TEXTILES/SHIRTS-TOPS/T_SHIRTS" + query: "sustainable organic eco-friendly"
+"corporate gifts under 10 euros" → query: "corporate gifts business professional" + price_max: 10
+"red Gildan t-shirts" → category: "TEXTILES/SHIRTS-TOPS/T_SHIRTS" + brand: "Gildan" + colors: "Red"
+
+### When NOT to use text query
+If the request maps entirely to filters, skip the query field:
+- "red polo shirts" → category + colors (no query needed)
+- "Gildan t-shirts under 5 euros" → category + brand + price (no query needed)
+
+### Response guidelines
+Since products appear as inline cards in the chat:
+- Write 1-3 sentences about what you found. You can be a bit more descriptive than a sidebar chat.
+- Highlight standout products briefly (e.g., "The Gildan Softstyle is a great value pick").
+- End with one optional follow-up question to help narrow down.
+- Do NOT list every product's details — the cards show images, prices, and colors.
+- If 0 results, suggest relaxing a filter or alternative search terms.
+
+### Product discovery flow
+1. ALWAYS search immediately when the user mentions products. Never delay to ask questions first.
+2. Use structured filters (category, brand, colors) over text query when possible.
+3. After showing results, ask ONE smart follow-up: occasion, budget, or nothing if both are known.
+4. Build on previous context — don't make the user repeat themselves.
+5. For curated final picks, search with specific product IDs.
+
+### When no results found
+If searchProducts returns 0 results:
+1. Immediately re-search with broader criteria (drop the most restrictive filter).
+2. Show the broader results and mention which constraint was relaxed.
+3. Never leave the user without product cards when discussing products.`;
+}
+
+// ---------------------------------------------------------------------------
+// POST handler
+// ---------------------------------------------------------------------------
+
+export async function POST(req: Request) {
+  const { messages: uiMessages } = await req.json();
+
+  const systemPrompt = await buildSystemPrompt();
+
+  const messages = await convertToModelMessages(uiMessages, {
+    ignoreIncompleteToolCalls: true,
+  });
+
+  const result = streamText({
+    model: anthropic("claude-sonnet-4-20250514"),
+    system: systemPrompt,
+    messages,
+    tools: {
+      searchProducts: tool({
+        description:
+          "Search the product catalog and display product cards inline in the chat. Use this whenever the user asks about products, wants to browse, or needs recommendations.",
+        inputSchema: z.object({
+          query: z
+            .string()
+            .optional()
+            .describe(
+              "Semantic text search query for materials, features, purposes",
+            ),
+          brand: z.string().optional().describe("Filter by brand name"),
+          category: z
+            .string()
+            .optional()
+            .describe(
+              "Filter by category code, e.g. TEXTILES/SHIRTS-TOPS/POLO",
+            ),
+          colors: z.string().optional().describe("Comma-separated color names"),
+          sizes: z.string().optional().describe("Comma-separated sizes"),
+          price_min: z.number().optional().describe("Minimum price in EUR"),
+          price_max: z.number().optional().describe("Maximum price in EUR"),
+          sort: z
+            .string()
+            .optional()
+            .describe(
+              "Sort order: price_min:asc, price_min:desc, updatedAt:desc, brand:asc",
+            ),
+          ids: z
+            .string()
+            .optional()
+            .describe(
+              "Comma-separated product IDs for a curated selection of specific products",
+            ),
+          limit: z
+            .number()
+            .optional()
+            .default(8)
+            .describe("Number of products to return (default 8, max 12)"),
+        }),
+        execute: async (args) => {
+          const params: Record<string, string> = {};
+          if (args.query) params.q = args.query;
+          if (args.brand) params.brand = args.brand;
+          if (args.category) params.category = args.category;
+          if (args.colors) params.colors = args.colors;
+          if (args.sizes) params.sizes = args.sizes;
+          if (args.price_min != null) params.price_min = String(args.price_min);
+          if (args.price_max != null) params.price_max = String(args.price_max);
+          if (args.sort) params.sort = args.sort;
+          if (args.ids) params.ids = args.ids;
+          if (args.limit) params.limit = String(args.limit);
+
+          // Build structured filters for "View all in catalog" link
+          const filtersApplied: Record<string, string> = {};
+          for (const [k, v] of Object.entries(params)) {
+            if (k !== "limit" && v) filtersApplied[k] = v;
+          }
+
+          try {
+            const searchResult = await searchStrapi(params);
+            const products = searchResult.data || [];
+            const total =
+              searchResult.meta?.pagination?.total || products.length;
+
+            if (total === 0) {
+              return {
+                products: [],
+                total: 0,
+                filters_applied: filtersApplied,
+                no_results: true,
+              };
+            }
+
+            const richProducts = products
+              .slice(0, args.limit || 8)
+              .map(mapToRichProduct);
+
+            return {
+              products: richProducts,
+              total,
+              filters_applied: filtersApplied,
+              no_results: false,
+            };
+          } catch {
+            return {
+              products: [],
+              total: 0,
+              query_used: "",
+              no_results: true,
+              error: "Search failed. Please try again.",
+            };
+          }
+        },
+      }),
+    },
+    stopWhen: stepCountIs(3),
+  });
+
+  return result.toUIMessageStreamResponse();
+}

--- a/frontend/src/app/api/chat/route.ts
+++ b/frontend/src/app/api/chat/route.ts
@@ -2,10 +2,9 @@ import { streamText, tool, stepCountIs, convertToModelMessages } from "ai";
 import { anthropic } from "@ai-sdk/anthropic";
 import { z } from "zod";
 import { readPrompts } from "@/app/api/admin/prompts/route";
+import { searchStrapi } from "@/lib/chat-search";
 
 export const maxDuration = 30;
-
-const STRAPI_BASE = process.env.STRAPI_INTERNAL_URL || "http://localhost:1337";
 
 // ---------------------------------------------------------------------------
 // Build system prompt from saved prompt sections + dynamic catalog context
@@ -150,23 +149,6 @@ The grid and sidebar show ALL product details. The user can see everything.
 - If 0 results, the grid keeps the previous view. Suggest relaxing a filter.
 - For curated final recommendations, use the ids parameter with specific product IDs.
 - When the user asks about available options (brands, colors), answer from the facet data — no tool call needed.${catalogContext}`;
-}
-
-async function searchStrapi(params: Record<string, string>) {
-  const qs = new URLSearchParams(params);
-  qs.set("limit", params.limit || "8");
-  qs.set("is_active", "true");
-  qs.set("facets", "brand,category,colors,sizes,supplier_name");
-
-  const res = await fetch(`${STRAPI_BASE}/api/products/search?${qs}`, {
-    headers: { "Content-Type": "application/json" },
-  });
-
-  if (!res.ok) {
-    throw new Error(`Search API responded ${res.status}`);
-  }
-
-  return res.json();
 }
 
 export async function POST(req: Request) {

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -296,15 +296,7 @@ const InlineProductGrid = React.memo(function InlineProductGrid({
   const products = output.products || [];
   const total = output.total || 0;
 
-  if (output.no_results || products.length === 0) {
-    return (
-      <div className="rounded-lg border border-sols-border/50 bg-sols-light-gray/50 p-3 text-center text-xs text-sols-muted">
-        No products found for this search.
-      </div>
-    );
-  }
-
-  // Build catalog link from structured filters
+  // Must be above early return to satisfy React Rules of Hooks
   const catalogUrl = useMemo(() => {
     const fa = output.filters_applied;
     if (!fa) return "/";
@@ -315,6 +307,14 @@ const InlineProductGrid = React.memo(function InlineProductGrid({
     const qs = params.toString();
     return qs ? `/?${qs}` : "/";
   }, [output.filters_applied]);
+
+  if (output.no_results || products.length === 0) {
+    return (
+      <div className="rounded-lg border border-sols-border/50 bg-sols-light-gray/50 p-3 text-center text-xs text-sols-muted">
+        No products found for this search.
+      </div>
+    );
+  }
 
   return (
     <div className="mt-2 space-y-2">

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -1,0 +1,929 @@
+"use client";
+
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useChat } from "@ai-sdk/react";
+import { DefaultChatTransport } from "ai";
+import Image from "next/image";
+import Link from "next/link";
+import { cn, formatPriceRange } from "@/lib/utils";
+import { ColorSwatch } from "@/components/ColorSwatch";
+import type { RichProduct } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// localStorage helpers
+// ---------------------------------------------------------------------------
+
+interface ConversationMeta {
+  id: string;
+  title: string;
+  lastMessageAt: number;
+  messageCount: number;
+}
+
+interface StoredMessage {
+  id: string;
+  role: "user" | "assistant";
+  parts: StoredPart[];
+  createdAt: number;
+}
+
+type StoredPart =
+  | { type: "text"; text: string }
+  | {
+      type: "tool-result";
+      toolName: string;
+      products: RichProduct[];
+      total: number;
+      noResults: boolean;
+    };
+
+const MAX_CONVERSATIONS = 30;
+
+function generateId(): string {
+  return crypto.randomUUID();
+}
+
+function loadConversations(): ConversationMeta[] {
+  try {
+    const raw = localStorage.getItem("chatbot_conversations");
+    return raw ? (JSON.parse(raw) as ConversationMeta[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveConversations(convos: ConversationMeta[]) {
+  try {
+    localStorage.setItem("chatbot_conversations", JSON.stringify(convos));
+  } catch {
+    // quota exceeded — silent
+  }
+}
+
+function loadMessages(conversationId: string): StoredMessage[] {
+  try {
+    const raw = localStorage.getItem(`chatbot_messages_${conversationId}`);
+    return raw ? (JSON.parse(raw) as StoredMessage[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveMessages(conversationId: string, messages: StoredMessage[]) {
+  try {
+    localStorage.setItem(
+      `chatbot_messages_${conversationId}`,
+      JSON.stringify(messages),
+    );
+  } catch {
+    // quota exceeded — silent
+  }
+}
+
+function deleteConversation(id: string) {
+  try {
+    localStorage.removeItem(`chatbot_messages_${id}`);
+  } catch {
+    // silent
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Lightweight markdown formatter for chat messages
+// Handles **bold**, *italic*, and line breaks — no external dependency needed.
+// ---------------------------------------------------------------------------
+
+function FormattedText({ text }: { text: string }) {
+  // Split into paragraphs on double newlines, single newlines become <br>
+  const paragraphs = text.split(/\n{2,}/);
+
+  return (
+    <>
+      {paragraphs.map((para, pi) => {
+        const lines = para.split("\n");
+        return (
+          <p key={pi} className={pi > 0 ? "mt-2" : undefined}>
+            {lines.map((line, li) => (
+              <span key={li}>
+                {li > 0 && <br />}
+                {formatInline(line)}
+              </span>
+            ))}
+          </p>
+        );
+      })}
+    </>
+  );
+}
+
+/** Parse **bold** and *italic* into <strong> and <em> spans */
+function formatInline(text: string): React.ReactNode[] {
+  const parts: React.ReactNode[] = [];
+  // Match **bold** or *italic* (non-greedy)
+  const re = /(\*\*(.+?)\*\*|\*(.+?)\*)/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = re.exec(text)) !== null) {
+    // Text before match
+    if (match.index > lastIndex) {
+      parts.push(text.slice(lastIndex, match.index));
+    }
+    if (match[2]) {
+      // **bold**
+      parts.push(
+        <strong key={match.index} className="font-semibold">
+          {match[2]}
+        </strong>,
+      );
+    } else if (match[3]) {
+      // *italic*
+      parts.push(<em key={match.index}>{match[3]}</em>);
+    }
+    lastIndex = match.index + match[0].length;
+  }
+
+  // Remaining text
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex));
+  }
+
+  return parts.length > 0 ? parts : [text];
+}
+
+// ---------------------------------------------------------------------------
+// Suggestion chips
+// ---------------------------------------------------------------------------
+
+const SUGGESTIONS = [
+  "Show me eco-friendly corporate gifts",
+  "Polo shirts under \u20AC15",
+  "Trade show giveaways under \u20AC5",
+  "Premium branded pens",
+];
+
+// ---------------------------------------------------------------------------
+// Inline product card for chat messages
+// ---------------------------------------------------------------------------
+
+const ChatProductCard = React.memo(function ChatProductCard({
+  product,
+}: {
+  product: RichProduct;
+}) {
+  const imgSrc = product.main_image_url || product.main_image_thumbnail_url;
+  const priceLabel = formatPriceRange(
+    product.price_min,
+    product.price_max,
+    product.currency,
+  );
+  const maxSwatches = 4;
+  const visibleColors = product.colors.slice(0, maxSwatches);
+  const overflowCount = product.colors.length - maxSwatches;
+
+  return (
+    <a
+      href={`/products/${product.id}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn(
+        "flex flex-col overflow-hidden rounded-xl border border-sols-border/60 bg-white",
+        "transition-all duration-200 hover:shadow-md hover:-translate-y-0.5",
+      )}
+    >
+      <div className="relative aspect-square overflow-hidden bg-sols-light-gray">
+        {imgSrc ? (
+          <Image
+            src={imgSrc}
+            alt={product.name}
+            width={200}
+            height={200}
+            className="h-full w-full object-contain p-2"
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center text-sols-muted/40">
+            <svg
+              className="h-10 w-10"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={1}
+            >
+              <path d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+          </div>
+        )}
+        {product.brand && (
+          <span className="absolute left-1.5 top-1.5 rounded-md bg-white/90 px-1.5 py-0.5 text-[10px] font-semibold text-sols-dark shadow-sm backdrop-blur-sm">
+            {product.brand}
+          </span>
+        )}
+      </div>
+
+      <div className="flex flex-1 flex-col gap-1 p-2.5">
+        <h4 className="line-clamp-2 text-xs font-semibold leading-snug text-sols-dark">
+          {product.name}
+        </h4>
+        {priceLabel && (
+          <p className="text-xs font-semibold text-sols-accent">{priceLabel}</p>
+        )}
+        {visibleColors.length > 0 && (
+          <div className="flex items-center gap-0.5 pt-0.5">
+            {visibleColors.map((color, i) => (
+              <ColorSwatch
+                key={`${color}-${i}`}
+                colorName={color}
+                hex={product.hex_colors?.[i]}
+                size="sm"
+                showTooltip
+              />
+            ))}
+            {overflowCount > 0 && (
+              <span className="ml-0.5 text-[10px] text-sols-muted">
+                +{overflowCount}
+              </span>
+            )}
+          </div>
+        )}
+        <p className="mt-auto text-[10px] text-sols-muted">
+          {product.supplier_name}
+        </p>
+      </div>
+    </a>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Inline product grid (rendered inside assistant messages)
+// ---------------------------------------------------------------------------
+
+interface ToolOutput {
+  products?: RichProduct[];
+  total?: number;
+  no_results?: boolean;
+  filters_applied?: Record<string, unknown>;
+  error?: string;
+}
+
+// Shared assistant avatar — used in messages and loading state
+function AssistantAvatar() {
+  return (
+    <div className="mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-sols-accent/10">
+      <svg
+        className="h-4 w-4 text-sols-accent"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={1.5}
+      >
+        <path d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456z" />
+      </svg>
+    </div>
+  );
+}
+
+const InlineProductGrid = React.memo(function InlineProductGrid({
+  output,
+}: {
+  output: ToolOutput;
+}) {
+  const products = output.products || [];
+  const total = output.total || 0;
+
+  if (output.no_results || products.length === 0) {
+    return (
+      <div className="rounded-lg border border-sols-border/50 bg-sols-light-gray/50 p-3 text-center text-xs text-sols-muted">
+        No products found for this search.
+      </div>
+    );
+  }
+
+  // Build catalog link from structured filters
+  const catalogUrl = useMemo(() => {
+    const fa = output.filters_applied;
+    if (!fa) return "/";
+    const params = new URLSearchParams();
+    for (const [key, val] of Object.entries(fa)) {
+      if (val != null && val !== "") params.set(key, String(val));
+    }
+    const qs = params.toString();
+    return qs ? `/?${qs}` : "/";
+  }, [output.filters_applied]);
+
+  return (
+    <div className="mt-2 space-y-2">
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
+        {products.map((p) => (
+          <ChatProductCard key={p.id} product={p} />
+        ))}
+      </div>
+      {total > products.length && (
+        <p className="text-center text-[11px] text-sols-muted">
+          Showing {products.length} of {total} products.{" "}
+          <Link href={catalogUrl} className="text-sols-accent hover:underline">
+            View all in catalog
+          </Link>
+        </p>
+      )}
+    </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Stored message renderer (for restored history)
+// ---------------------------------------------------------------------------
+
+function StoredMessageBubble({ msg }: { msg: StoredMessage }) {
+  return (
+    <div
+      className={cn(
+        "flex gap-3",
+        msg.role === "user" ? "justify-end" : "justify-start",
+      )}
+    >
+      {msg.role === "assistant" && <AssistantAvatar />}
+      <div
+        className={cn(
+          "max-w-[min(85%,56ch)] space-y-2",
+          msg.role === "user" ? "text-right" : "text-left",
+        )}
+      >
+        {msg.parts.map((part, i) => {
+          if (part.type === "text" && part.text.trim()) {
+            return (
+              <div
+                key={i}
+                className={cn(
+                  "rounded-2xl px-4 py-2.5 text-sm leading-relaxed",
+                  msg.role === "user"
+                    ? "inline-block rounded-br-md bg-sols-accent text-white"
+                    : "rounded-bl-md bg-sols-light-gray text-sols-dark",
+                )}
+              >
+                {msg.role === "assistant" ? (
+                  <FormattedText text={part.text} />
+                ) : (
+                  part.text
+                )}
+              </div>
+            );
+          }
+          if (part.type === "tool-result") {
+            return (
+              <InlineProductGrid
+                key={i}
+                output={{
+                  products: part.products,
+                  total: part.total,
+                  no_results: part.noResults,
+                }}
+              />
+            );
+          }
+          return null;
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main chat page
+// ---------------------------------------------------------------------------
+
+export default function ChatPage() {
+  const transport = useMemo(
+    () => new DefaultChatTransport({ api: "/api/chat-bot" }),
+    [],
+  );
+  const { messages, sendMessage, setMessages, status } = useChat({
+    transport,
+  });
+
+  const [input, setInput] = useState("");
+  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [conversations, setConversations] = useState<ConversationMeta[]>([]);
+  const [activeConversationId, setActiveConversationId] = useState("");
+  const [restoredMessages, setRestoredMessages] = useState<StoredMessage[]>([]);
+
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const initRef = useRef(false);
+
+  // Initialize on mount
+  useEffect(() => {
+    if (initRef.current) return;
+    initRef.current = true;
+
+    const convos = loadConversations();
+    setConversations(convos);
+
+    // Start a new conversation
+    const newId = generateId();
+    setActiveConversationId(newId);
+  }, []);
+
+  // Auto-scroll on new messages
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, restoredMessages]);
+
+  // Auto-resize textarea
+  useEffect(() => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    ta.style.height = "auto";
+    ta.style.height = `${Math.min(ta.scrollHeight, 160)}px`;
+  }, [input]);
+
+  // Persist messages to localStorage when stream completes
+  useEffect(() => {
+    if (status !== "ready" || messages.length === 0 || !activeConversationId)
+      return;
+
+    const stored: StoredMessage[] = messages.map((msg) => {
+      const parts: StoredPart[] = [];
+      for (const part of msg.parts) {
+        if (part.type === "text" && "text" in part) {
+          const text = (part as { type: "text"; text: string }).text;
+          if (text.trim()) {
+            parts.push({ type: "text", text });
+          }
+        } else if (
+          part.type.startsWith("tool-") &&
+          "state" in part &&
+          part.state === "output-available" &&
+          "output" in part
+        ) {
+          const output = part.output as ToolOutput;
+          parts.push({
+            type: "tool-result",
+            toolName: "searchProducts",
+            products: output.products || [],
+            total: output.total || 0,
+            noResults: output.no_results || false,
+          });
+        }
+      }
+      return {
+        id: msg.id,
+        role: msg.role as "user" | "assistant",
+        parts,
+        createdAt: Date.now(),
+      };
+    });
+
+    saveMessages(activeConversationId, stored);
+
+    // Update conversation meta — use in-memory state, not redundant localStorage read
+    const allConvos = [...conversations];
+    const existingIdx = allConvos.findIndex(
+      (c) => c.id === activeConversationId,
+    );
+    const firstUserMsg = messages.find((m) => m.role === "user");
+    const title = firstUserMsg
+      ? (
+          firstUserMsg.parts.find(
+            (p): p is { type: "text"; text: string } => p.type === "text",
+          ) as { text: string } | undefined
+        )?.text?.slice(0, 60) || "New conversation"
+      : "New conversation";
+
+    const meta: ConversationMeta = {
+      id: activeConversationId,
+      title,
+      lastMessageAt: Date.now(),
+      messageCount: messages.length,
+    };
+
+    if (existingIdx >= 0) {
+      allConvos[existingIdx] = meta;
+    } else {
+      allConvos.unshift(meta);
+    }
+
+    // Trim to max
+    while (allConvos.length > MAX_CONVERSATIONS) {
+      const removed = allConvos.pop();
+      if (removed) deleteConversation(removed.id);
+    }
+
+    saveConversations(allConvos);
+    setConversations(allConvos);
+  }, [status, messages, activeConversationId]);
+
+  const isLoading = status === "streaming" || status === "submitted";
+
+  const handleSend = useCallback(
+    (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed || isLoading) return;
+      setInput("");
+      sendMessage({ text: trimmed });
+    },
+    [isLoading, sendMessage],
+  );
+
+  const handleNewChat = useCallback(() => {
+    const newId = generateId();
+    setActiveConversationId(newId);
+    setMessages([]);
+    setRestoredMessages([]);
+    setInput("");
+    textareaRef.current?.focus();
+  }, [setMessages]);
+
+  const handleSwitchConversation = useCallback(
+    (convoId: string) => {
+      if (convoId === activeConversationId) return;
+      setActiveConversationId(convoId);
+      setMessages([]);
+      const stored = loadMessages(convoId);
+      setRestoredMessages(stored);
+      setInput("");
+    },
+    [activeConversationId, setMessages],
+  );
+
+  const handleDeleteConversation = useCallback(
+    (convoId: string, e: React.MouseEvent) => {
+      e.stopPropagation();
+      deleteConversation(convoId);
+      const updated = conversations.filter((c) => c.id !== convoId);
+      saveConversations(updated);
+      setConversations(updated);
+      if (convoId === activeConversationId) {
+        handleNewChat();
+      }
+    },
+    [conversations, activeConversationId, handleNewChat],
+  );
+
+  const showRestoredHistory =
+    restoredMessages.length > 0 && messages.length === 0;
+  const hasAnyMessages = restoredMessages.length > 0 || messages.length > 0;
+
+  const isToolSearching = useMemo(
+    () =>
+      messages.some(
+        (m) =>
+          m.role === "assistant" &&
+          m.parts.some(
+            (p) =>
+              p.type.startsWith("tool-") &&
+              "state" in p &&
+              (p.state === "input-streaming" || p.state === "streaming"),
+          ),
+      ),
+    [messages],
+  );
+
+  return (
+    <div className="flex h-[calc(100vh-3.5rem)]">
+      {/* ----------------------------------------------------------------- */}
+      {/* Sidebar */}
+      {/* ----------------------------------------------------------------- */}
+      <aside
+        className={cn(
+          "flex flex-col border-r border-sols-border bg-white transition-all duration-200",
+          sidebarOpen ? "w-64 shrink-0" : "w-0 overflow-hidden",
+          "max-lg:fixed max-lg:inset-y-14 max-lg:left-0 max-lg:z-50 max-lg:shadow-xl",
+          !sidebarOpen && "max-lg:hidden",
+        )}
+      >
+        {/* Sidebar header */}
+        <div className="flex items-center gap-2 border-b border-sols-border p-3">
+          <button
+            type="button"
+            onClick={handleNewChat}
+            className={cn(
+              "flex flex-1 items-center justify-center gap-2 rounded-lg px-3 py-2",
+              "bg-sols-accent text-white text-sm font-semibold",
+              "transition-colors hover:bg-sols-accent-hover",
+            )}
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path d="M12 4v16m8-8H4" />
+            </svg>
+            New Chat
+          </button>
+        </div>
+
+        {/* Conversation list */}
+        <nav className="flex-1 overflow-y-auto p-2">
+          {conversations.length === 0 && (
+            <p className="px-2 py-4 text-center text-xs text-sols-muted">
+              No conversations yet
+            </p>
+          )}
+          {conversations.map((convo) => (
+            <div
+              key={convo.id}
+              role="button"
+              tabIndex={0}
+              onClick={() => handleSwitchConversation(convo.id)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ")
+                  handleSwitchConversation(convo.id);
+              }}
+              className={cn(
+                "group flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm transition-colors cursor-pointer",
+                convo.id === activeConversationId
+                  ? "bg-sols-light-gray font-semibold text-sols-dark"
+                  : "text-sols-muted hover:bg-sols-light-gray/50 hover:text-sols-dark",
+              )}
+            >
+              <svg
+                className="h-4 w-4 shrink-0"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.5}
+              >
+                <path d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+              </svg>
+              <span className="flex-1 truncate">{convo.title}</span>
+              <button
+                type="button"
+                onClick={(e) => handleDeleteConversation(convo.id, e)}
+                className="hidden shrink-0 rounded p-0.5 text-sols-muted hover:text-red-500 group-hover:block"
+                title="Delete conversation"
+              >
+                <svg
+                  className="h-3.5 w-3.5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+              </button>
+            </div>
+          ))}
+        </nav>
+      </aside>
+
+      {/* ----------------------------------------------------------------- */}
+      {/* Main chat area */}
+      {/* ----------------------------------------------------------------- */}
+      <div className="flex min-w-0 flex-1 flex-col">
+        {/* Chat header bar */}
+        <div className="flex items-center gap-3 border-b border-sols-border bg-white px-4 py-2.5">
+          <button
+            type="button"
+            onClick={() => setSidebarOpen((prev) => !prev)}
+            className="rounded-lg p-1.5 text-sols-muted transition-colors hover:bg-sols-light-gray hover:text-sols-dark"
+            title={sidebarOpen ? "Close sidebar" : "Open sidebar"}
+          >
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={1.5}
+            >
+              <path d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+            </svg>
+          </button>
+          <div className="flex items-center gap-2">
+            <div className="h-2 w-2 rounded-full bg-green-400" />
+            <span className="text-sm font-semibold text-sols-dark">
+              PromoAtlas Assistant
+            </span>
+          </div>
+        </div>
+
+        {/* Messages scroll area */}
+        <div className="flex-1 overflow-y-auto">
+          <div className="mx-auto max-w-3xl px-4 py-6">
+            {/* Welcome state */}
+            {!hasAnyMessages && (
+              <div className="flex min-h-[60vh] flex-col items-center justify-center gap-8">
+                <div className="text-center">
+                  <span className="text-4xl font-extrabold tracking-tight text-sols-dark">
+                    Promo<span className="text-sols-accent">Atlas</span>
+                  </span>
+                  <p className="mt-2 text-sols-muted">
+                    Find the perfect promotional products for your brand
+                  </p>
+                </div>
+                <div className="grid w-full max-w-lg grid-cols-2 gap-3">
+                  {SUGGESTIONS.map((suggestion) => (
+                    <button
+                      key={suggestion}
+                      type="button"
+                      onClick={() => handleSend(suggestion)}
+                      className={cn(
+                        "rounded-xl border border-sols-border px-4 py-3 text-left text-sm text-sols-dark",
+                        "transition-all hover:border-sols-accent/30 hover:bg-sols-light-gray/50 hover:shadow-sm",
+                      )}
+                    >
+                      {suggestion}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Restored history messages */}
+            {showRestoredHistory && (
+              <div className="space-y-4">
+                {restoredMessages.map((msg) => (
+                  <StoredMessageBubble key={msg.id} msg={msg} />
+                ))}
+              </div>
+            )}
+
+            {/* Live messages */}
+            {messages.length > 0 && (
+              <div className="space-y-4">
+                {messages.map((msg) => (
+                  <div
+                    key={msg.id}
+                    className={cn(
+                      "flex gap-3",
+                      msg.role === "user" ? "justify-end" : "justify-start",
+                    )}
+                  >
+                    {msg.role === "assistant" && <AssistantAvatar />}
+
+                    <div
+                      className={cn(
+                        "max-w-[min(85%,56ch)] space-y-2",
+                        msg.role === "user" ? "text-right" : "text-left",
+                      )}
+                    >
+                      {/* Render parts in order so text after tools appears below cards */}
+                      {msg.parts.map((part, i) => {
+                        // Text part
+                        if (part.type === "text") {
+                          const text = (part as { type: "text"; text: string })
+                            .text;
+                          if (!text?.trim()) return null;
+                          return (
+                            <div
+                              key={i}
+                              className={cn(
+                                "rounded-2xl px-4 py-2.5 text-sm leading-relaxed",
+                                msg.role === "user"
+                                  ? "inline-block rounded-br-md bg-sols-accent text-white"
+                                  : "rounded-bl-md bg-sols-light-gray text-sols-dark",
+                              )}
+                            >
+                              {msg.role === "assistant" ? (
+                                <FormattedText text={text} />
+                              ) : (
+                                text
+                              )}
+                            </div>
+                          );
+                        }
+
+                        // Tool part — check states
+                        if (part.type.startsWith("tool-") && "state" in part) {
+                          // Streaming / loading state
+                          if (
+                            part.state === "input-streaming" ||
+                            part.state === "streaming"
+                          ) {
+                            return (
+                              <div
+                                key={`search-${i}`}
+                                className="flex items-center gap-2 rounded-lg bg-sols-light-gray/50 px-3 py-2 text-xs text-sols-muted"
+                              >
+                                <svg
+                                  className="h-4 w-4 animate-spin"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <circle
+                                    className="opacity-25"
+                                    cx="12"
+                                    cy="12"
+                                    r="10"
+                                    stroke="currentColor"
+                                    strokeWidth="4"
+                                  />
+                                  <path
+                                    className="opacity-75"
+                                    fill="currentColor"
+                                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                                  />
+                                </svg>
+                                Searching products...
+                              </div>
+                            );
+                          }
+
+                          // Output available — render product cards
+                          if (part.state === "output-available") {
+                            const output = (
+                              "output" in part ? part.output : null
+                            ) as ToolOutput | null;
+                            if (!output) return null;
+                            return (
+                              <InlineProductGrid
+                                key={`tool-${i}`}
+                                output={output}
+                              />
+                            );
+                          }
+                        }
+
+                        return null;
+                      })}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Loading dots — only when streaming text, not during tool search */}
+            {isLoading && !isToolSearching && (
+              <div className="mt-4 flex items-center gap-3">
+                <AssistantAvatar />
+                <div className="flex items-center gap-1.5">
+                  <span className="h-2 w-2 animate-bounce rounded-full bg-sols-muted [animation-delay:-0.3s]" />
+                  <span className="h-2 w-2 animate-bounce rounded-full bg-sols-muted [animation-delay:-0.15s]" />
+                  <span className="h-2 w-2 animate-bounce rounded-full bg-sols-muted" />
+                </div>
+              </div>
+            )}
+
+            <div ref={messagesEndRef} />
+          </div>
+        </div>
+
+        {/* ----------------------------------------------------------------- */}
+        {/* Input bar */}
+        {/* ----------------------------------------------------------------- */}
+        <div className="border-t border-sols-border bg-white px-4 py-4">
+          <div className="mx-auto max-w-3xl">
+            <div
+              className={cn(
+                "flex items-end gap-3 rounded-2xl border border-sols-border/60",
+                "bg-white px-4 py-3 shadow-sm",
+                "focus-within:border-sols-mid-gray focus-within:shadow-md",
+                "transition-all",
+              )}
+            >
+              <textarea
+                ref={textareaRef}
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    handleSend(input);
+                  }
+                }}
+                placeholder="Ask about products, quotes, delivery times..."
+                rows={1}
+                className={cn(
+                  "max-h-40 flex-1 resize-none bg-transparent text-sm text-sols-dark",
+                  "placeholder:text-sols-muted/60 focus:outline-none",
+                )}
+              />
+              <button
+                type="button"
+                onClick={() => handleSend(input)}
+                disabled={!input.trim() || isLoading}
+                className={cn(
+                  "flex h-9 w-9 shrink-0 items-center justify-center rounded-xl",
+                  "bg-sols-accent text-white transition-colors",
+                  "hover:bg-sols-accent-hover disabled:cursor-not-allowed disabled:opacity-40",
+                )}
+              >
+                <svg
+                  className="h-4 w-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path d="M5 12h14M12 5l7 7-7 7" />
+                </svg>
+              </button>
+            </div>
+            <p className="mt-2 text-center text-[11px] text-sols-muted">
+              PromoAtlas AI &middot; Powered by Claude
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -39,6 +39,12 @@ export default function RootLayout({
                 >
                   Catalog
                 </Link>
+                <Link
+                  href="/chat"
+                  className="transition-colors hover:text-sols-dark"
+                >
+                  AI Chat
+                </Link>
               </nav>
             </div>
           </header>

--- a/frontend/src/lib/chat-search.ts
+++ b/frontend/src/lib/chat-search.ts
@@ -1,0 +1,65 @@
+// ---------------------------------------------------------------------------
+// Shared search helpers for chat API routes
+// ---------------------------------------------------------------------------
+
+import type { RichProduct } from "./types";
+
+const STRAPI_BASE = process.env.STRAPI_INTERNAL_URL || "http://localhost:1337";
+
+/**
+ * Query the Strapi MeiliSearch search endpoint.
+ * Used by both /api/chat and /api/chat-bot routes.
+ */
+export async function searchStrapi(params: Record<string, string>) {
+  const qs = new URLSearchParams(params);
+  if (!params.limit) qs.set("limit", "8");
+  qs.set("is_active", "true");
+  qs.set("facets", "brand,category,colors,sizes,supplier_name");
+
+  const res = await fetch(`${STRAPI_BASE}/api/products/search?${qs}`, {
+    headers: { "Content-Type": "application/json" },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Search API responded ${res.status}`);
+  }
+
+  return res.json();
+}
+
+/**
+ * Map a raw MeiliSearch product document to a RichProduct for inline chat display.
+ */
+export function mapToRichProduct(p: Record<string, unknown>): RichProduct {
+  const name =
+    (p.name_en as string) ||
+    (p.name_de as string) ||
+    (p.name_fr as string) ||
+    (p.name_es as string) ||
+    (p.sku as string) ||
+    "";
+
+  const rawDesc =
+    (p.description_en as string) ||
+    (p.description_de as string) ||
+    (p.description_fr as string) ||
+    "";
+  const description = rawDesc ? rawDesc.slice(0, 120) : undefined;
+
+  return {
+    id: p.id as string,
+    name,
+    brand: (p.brand as string) || undefined,
+    price_min: p.price_min as number | undefined,
+    price_max: p.price_max as number | undefined,
+    currency: (p.currency as string) || "EUR",
+    colors: (p.colors as string[]) || [],
+    hex_colors: (p.hex_colors as string[]) || [],
+    category: (p.category as string) || undefined,
+    supplier_name: (p.supplier_name as string) || "",
+    main_image_url: (p.main_image_url as string) || undefined,
+    main_image_thumbnail_url:
+      (p.main_image_thumbnail_url as string) || undefined,
+    description,
+  };
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -252,6 +252,23 @@ export interface Product {
   updatedAt: string;
 }
 
+/** Rich product for inline chat display (includes images + descriptions) */
+export interface RichProduct {
+  id: string;
+  name: string;
+  brand?: string;
+  price_min?: number;
+  price_max?: number;
+  currency: string;
+  colors: string[];
+  hex_colors: string[];
+  category?: string;
+  supplier_name: string;
+  main_image_url?: string;
+  main_image_thumbnail_url?: string;
+  description?: string;
+}
+
 export interface StrapiResponse<T> {
   data: T;
   meta?: Record<string, unknown>;

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -58,6 +58,20 @@ export function formatPrice(
   }).format(price);
 }
 
+/** Format a min/max price range as a human-readable string */
+export function formatPriceRange(
+  priceMin: number | undefined | null,
+  priceMax: number | undefined | null,
+  currency: string = "EUR",
+): string | null {
+  if (priceMin != null && priceMax != null) {
+    if (priceMin === priceMax) return formatPrice(priceMin, currency);
+    return `${formatPrice(priceMin, currency)} – ${formatPrice(priceMax, currency)}`;
+  }
+  if (priceMin != null) return `from ${formatPrice(priceMin, currency)}`;
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // Color utilities
 // ---------------------------------------------------------------------------
@@ -109,10 +123,7 @@ const COLOR_MAP: Record<string, string> = {
 const HEX_RE = /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/;
 
 /** Map a color name to a hex value. Prefer existingHex if it looks valid. */
-export function getColorHex(
-  colorName: string,
-  existingHex?: string,
-): string {
+export function getColorHex(colorName: string, existingHex?: string): string {
   if (existingHex && HEX_RE.test(existingHex)) return existingHex;
 
   const key = colorName.toLowerCase().trim();


### PR DESCRIPTION
## Summary
- Add independent `/chat` page with Claude-style full-screen chatbot UI
- Products render as rich inline cards (images, prices, colors) in the conversation
- Reuses existing MeiliSearch hybrid search infrastructure — no backend changes needed
- Sidebar with localStorage-persisted conversation history (up to 30 conversations)
- Welcome state with suggestion chips, markdown formatting, auto-scroll

## New files
- `frontend/src/app/chat/page.tsx` — Full-screen chatbot page
- `frontend/src/app/api/chat-bot/route.ts` — API route with `searchProducts` tool
- `frontend/src/lib/chat-search.ts` — Shared search helpers (extracted from catalog route)

## Changes to existing files
- `frontend/src/app/api/chat/route.ts` — Import `searchStrapi` from shared module
- `frontend/src/lib/types.ts` — Added `RichProduct` interface
- `frontend/src/lib/utils.ts` — Added `formatPriceRange` utility
- `frontend/src/app/layout.tsx` — Added "AI Chat" nav link
- `backend/.../meilisearch-types.ts` — Fixed duplicate `hybrid` property

## Test plan
- [ ] Visit `/chat` — verify welcome state with logo and suggestion chips
- [ ] Click a suggestion chip — verify products render inline as cards
- [ ] Send a follow-up message — verify text appears below product cards
- [ ] Click a product card — verify it opens `/products/[id]` in new tab
- [ ] Click "View all in catalog" — verify it navigates to `/` with filters
- [ ] Refresh page — verify conversation persists in sidebar
- [ ] Switch between conversations in sidebar
- [ ] Create new chat — verify clean state
- [ ] Verify existing catalog page at `/` still works independently
- [ ] Verify markdown formatting (**bold**, *italic*) renders in responses

🤖 Generated with [Claude Code](https://claude.ai/claude-code)