### PR TITLE
chore: fix ESLint errors, run Prettier, update documentation

### DIFF
--- a/.claude/ARCHITECTURE.md
+++ b/.claude/ARCHITECTURE.md
@@ -10,10 +10,10 @@ System design for PromoAtlas PIM. For implementation patterns, see PATTERNS.md.
 ┌─────────────────┐         ┌─────────────────┐         ┌─────────────────┐
 │  React Frontend │────────▶│  Strapi Backend │────────▶│   PostgreSQL    │
 │  (Port 3000)    │  REST   │  (Port 1337)    │  pg     │  (local:5433)   │
-└─────────────────┘         └─────────────────┘         └─────────────────┘
-                                     │
-                    ┌────────────────┼────────────────┐
-                    ▼                ▼                ▼
+│                 │         └─────────────────┘         └─────────────────┘
+│  /  = Catalog   │                  │
+│  /chat = Chatbot│   ┌──────────────┼────────────────┐
+└─────────────────┘   ▼              ▼                ▼
             ┌───────────┐    ┌───────────┐    ┌───────────┐
             │ R2/SeaweedFS   │ Promidata │    │MeiliSearch│
             │  (Images) │    │   API     │    │  (7700)   │
@@ -211,6 +211,29 @@ Supplier: {{ doc.supplier_name }}.
 
 **Auth**: Email/password login against env vars, HTTP-only cookie session (24hr).
 
+## Standalone Chatbot (`/chat`)
+
+A full-screen conversational interface independent from the catalog page. No shared filter state, no sidebar, no product grid -- products render as rich inline cards directly in the chat stream.
+
+### How It Differs From the Catalog Chat
+
+| Aspect | Catalog Chat (`/`) | Standalone Chatbot (`/chat`) |
+|--------|-------------------|------------------------------|
+| Tool | `updateCatalogFilters` | `searchProducts` |
+| API route | `/api/chat` | `/api/chat-bot` |
+| Products display | Grid updates via shared `SearchParams` | Inline cards in conversation |
+| Filter state | Shared with sidebar + URL | None -- each search is independent |
+| Conversation history | Lost on page reload | Persisted in localStorage (up to 30 conversations) |
+
+### Key Features
+
+- **Inline product cards** -- Images, prices, color swatches, and brand badges rendered directly in assistant messages. Cards link to `/products/[id]` (opens in new tab).
+- **Conversation sidebar** -- Switch between saved conversations. New Chat button starts a fresh thread.
+- **localStorage persistence** -- Messages serialized after each AI response completes. Up to 30 conversations retained; oldest pruned automatically.
+- **`searchProducts` tool** -- AI decomposes queries into structured filters (category, brand, colors, price) + semantic text query, same as the catalog chat but returns `RichProduct` objects for inline rendering instead of `filters_applied`.
+- **Shared search infrastructure** -- Both `/api/chat` and `/api/chat-bot` use `lib/chat-search.ts` (`searchStrapi` + `mapToRichProduct`) to query MeiliSearch with hybrid search.
+- **Suggestion chips** -- Empty state shows starter prompts to guide first interaction.
+
 ## Frontend Architecture
 
 ### Directory Structure
@@ -219,9 +242,11 @@ Supplier: {{ doc.supplier_name }}.
 frontend/src/
 ├── app/
 │   ├── page.tsx              # Catalog page (unified filter state)
+│   ├── chat/page.tsx         # Standalone AI chatbot (full-screen, localStorage history)
 │   ├── admin/page.tsx        # Admin prompt editor
 │   └── api/
-│       ├── chat/route.ts     # AI chat endpoint (Vercel AI SDK + Claude)
+│       ├── chat/route.ts     # Catalog chat endpoint (updateCatalogFilters tool)
+│       ├── chat-bot/route.ts # Standalone chatbot endpoint (searchProducts tool)
 │       └── admin/            # Prompt CRUD + auth
 ├── components/
 │   ├── ChatPanel.tsx         # AI chat (useChat, filter extraction)
@@ -232,6 +257,7 @@ frontend/src/
 │   └── filters/              # Category, Brand, Color, Size, Price filters
 ├── lib/
 │   ├── chat-context.tsx      # Chat panel + sidebar state
+│   ├── chat-search.ts        # Shared MeiliSearch search helpers (used by both chat routes)
 │   ├── api.ts                # MeiliSearch API client
 │   ├── types.ts              # All TypeScript interfaces
 │   └── utils.ts              # Formatting, color mapping

--- a/.claude/DECISIONS.md
+++ b/.claude/DECISIONS.md
@@ -6,6 +6,22 @@ Decision log for PromoAtlas PIM. Keep decisions concise: Context → Decision �
 
 ---
 
+## [2026-04-02] Standalone Full-Screen AI Chatbot Page
+
+**Context**: The unified catalog+chat page works well for filter-driven product discovery, but some users prefer a pure conversational experience — like ChatGPT/Claude style — where products appear inline in the chat without a catalog grid or sidebar filters.
+
+**Decisions**:
+1. **Independent `/chat` route** — Not a mode toggle on the catalog page. Completely separate page with its own API route, state, and UX.
+2. **Reuse MeiliSearch infrastructure** — Same `searchStrapi()` (extracted to `lib/chat-search.ts`), same hybrid search, same product index. No backend changes needed.
+3. **`searchProducts` tool (not `updateCatalogFilters`)** — Returns rich product data (images, descriptions, prices, colors) for inline rendering. No `filters_applied` for grid control.
+4. **localStorage for conversation history** — Anonymous sessions, no auth required. Up to 30 conversations stored per browser. Sidebar for switching.
+5. **`DefaultChatTransport`** — AI SDK v6 removed `api` option from `useChat()`. Must use `new DefaultChatTransport({ api: "/api/chat-bot" })` instead.
+6. **Shared prompt sections** — Loads `regularPrompt`, `companyKnowledge`, `industryKnowledge`, `brandVoice` from admin prompts. Intentionally skips `preSearchQuestions` and `productSearchFlow` (catalog-specific).
+
+**Consequences**: Two chat experiences: catalog page for structured browsing, `/chat` for conversational discovery. Both use the same search backend. Admin prompt changes to personality/knowledge sections apply to both; catalog-specific prompt sections only apply to the catalog chat panel.
+
+---
+
 ## [2026-04-02] AI Chat + Catalog Unified Filter Architecture + Hybrid Search
 
 **Context**: The AI chat widget and the product catalog were mutually exclusive — `isChatMode` replaced the grid with AI results, hid the sidebar, abandoned the URL, and offered no way to refine. Chat had no awareness of active filters or available facets. MeiliSearch hybrid search embedder was configured (`product_search` with OpenAI text-embedding-3-small) but never wired into search queries.

--- a/.claude/GOTCHAS.md
+++ b/.claude/GOTCHAS.md
@@ -36,6 +36,9 @@ Active gotchas in PromoAtlas PIM. Fixed issues archived in git history.
 | **Chat Panel Must Stay Mounted** | Returning `null` when closed destroys `useChat` state (all messages lost) | Use CSS `hidden` class, never `if (!open) return null` |
 | **Tool-Grid Result Mismatch** | AI tool queries MeiliSearch independently; if it doesn't carry forward existing filters, tool count differs from grid | Tool now merges AI args with `currentFilters` on server before querying |
 | **Hybrid Search Latency** | Hybrid search with embeddings takes ~2s vs ~50ms keyword-only | Only activates when text query is present; filter-only searches stay fast |
+| **AI SDK v6 useChat Transport** | `useChat()` no longer accepts `api` option directly. Must use `transport: new DefaultChatTransport({ api: "/api/chat-bot" })` from `ai` package | Import `DefaultChatTransport` from `ai`, pass via `transport` option |
+| **AI SDK v6 Tool Part States** | Tool part `state` values changed in v6. No `"call"` or `"partial-call"` states. Valid streaming states are `"input-streaming"` and `"streaming"` | Check SDK types for valid states before using in conditionals |
+| **React.memo + useMemo Order** | `useMemo` inside a `React.memo` component must be called before any early returns, or React throws "rendered more hooks" error | Always place all hooks above conditional returns |
 
 ## Infrastructure
 

--- a/.claude/STACK.md
+++ b/.claude/STACK.md
@@ -170,32 +170,32 @@ Complete technology stack for PromoAtlas PIM system with versions and rationale.
 - **Environment**: Coolify PostgreSQL, Coolify Redis, Cloudflare R2
 
 ### Frontend Deployment
-- **Target**: Vercel (configured via `vercel.json` for SPA routing)
+- **Target**: Coolify (same as backend)
 - **Build Command**: `npm run build`
-- **Output**: `dist/` directory
-- **SPA Routing**: All routes rewrite to `index.html` for React Router
+- **Output**: `.next/` directory
+- **Routing**: Next.js App Router (file-system based)
 
 ## Version Summary Table
 
 | Category | Technology | Version | Purpose |
 |----------|-----------|---------|---------|
 | Backend Framework | Strapi | 5.17.0 | Headless CMS & API |
-| Frontend Framework | React | 18.2.0 | UI library |
+| Frontend Framework | Next.js | 16.2.2 | Full-stack React framework |
+| UI Library | React | 19.2.4 | UI library |
 | Language | TypeScript | 5.2.2 (FE), 5.7.3 (BE) | Type safety |
-| Build Tool (FE) | Vite | 5.0.8 | Fast dev & build |
+| Build Tool (FE) | Next.js Turbopack | - | Build tool and dev server |
 | Database | PostgreSQL | - | Data storage |
 | DB Driver | pg | 8.16.3 | Database connection |
 | Storage | Cloudflare R2 | - | Image hosting |
 | AWS SDK | @aws-sdk/client-s3 | 3.844.0 | R2 integration |
 | Search Engine | Meilisearch | 0.54.0 | Full-text search |
-| AI/RAG | @google/genai | 1.30.0 | Gemini FileSearchStore |
+| AI Chat | Vercel AI SDK | 6.0.143 | Streaming AI chat |
 | HTTP Client | node-fetch | 2.7.0 | API calls |
 | HTTP Client | axios | - | Retry-enabled API calls |
 | Queue System | BullMQ | 5.0.0 | Background jobs |
 | Queue UI | @bull-board/* | - | Queue monitoring |
 | Redis Client | ioredis | 5.3.0 | Queue backend |
 | Testing | Jest | 30.2.0 | Unit tests |
-| Routing | React Router DOM | 6.26.0 | Client routing |
 | Node Runtime | Node.js | 18-22 | Server runtime |
 
 ## Key Technology Decisions
@@ -207,11 +207,12 @@ Complete technology stack for PromoAtlas PIM system with versions and rationale.
 - Lifecycle hooks for custom logic (AutoRAG sync)
 - Built-in REST API with filtering, pagination, population
 
-### Why React + Vite (not Next.js)?
-- Simple SPA requirements (no SSR needed)
-- Vite provides faster dev experience
-- Simpler deployment (static build)
-- Backend already handles API (Strapi)
+### Why Next.js 16 (migrated from React + Vite)?
+- Server-side API routes for AI streaming (Vercel AI SDK `streamText`)
+- Turbopack for fast development builds
+- App Router with file-system routing
+- Static + dynamic rendering (product detail pages use ISR)
+- API route proxying to Strapi via `next.config.ts` rewrites
 
 ### Why CSS Modules (not Tailwind/styled-components)?
 - Zero runtime overhead

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -26,13 +26,15 @@ const SECTIONS: PromptSection[] = [
   {
     key: "regularPrompt",
     label: "Regular Prompt",
-    description: "The main system prompt defining the assistant's persona and behavior",
+    description:
+      "The main system prompt defining the assistant's persona and behavior",
     placeholder: "Define the AI assistant's core identity and instructions...",
   },
   {
     key: "companyKnowledge",
     label: "Company Knowledge",
-    description: "Information about your company, products, and internal processes",
+    description:
+      "Information about your company, products, and internal processes",
     placeholder: "Describe your company, product range, service areas...",
   },
   {
@@ -44,20 +46,23 @@ const SECTIONS: PromptSection[] = [
   {
     key: "preSearchQuestions",
     label: "Pre-Search Questions",
-    description: "Questions to collect from users before searching for products",
+    description:
+      "Questions to collect from users before searching for products",
     placeholder: "List the qualifying questions the assistant should ask...",
   },
   {
     key: "productSearchFlow",
     label: "Product Search Flow",
-    description: "The step-by-step search behavior instructions for the assistant",
+    description:
+      "The step-by-step search behavior instructions for the assistant",
     placeholder: "Define the stages of product discovery and recommendation...",
   },
   {
     key: "brandVoice",
     label: "Brand Voice & Tone",
     description: "Define how the chatbot should communicate with customers",
-    placeholder: "Describe the communication style, tone, and language preferences...",
+    placeholder:
+      "Describe the communication style, tone, and language preferences...",
   },
 ];
 
@@ -316,11 +321,7 @@ function PromptEditor({ onLogout }: { onLogout: () => void }) {
     return (
       <div className="flex min-h-[calc(100vh-56px)] items-center justify-center">
         <div className="flex items-center gap-3 text-sm text-[#6B7280]">
-          <svg
-            className="h-5 w-5 animate-spin"
-            fill="none"
-            viewBox="0 0 24 24"
-          >
+          <svg className="h-5 w-5 animate-spin" fill="none" viewBox="0 0 24 24">
             <circle
               className="opacity-25"
               cx="12"
@@ -454,11 +455,7 @@ export default function AdminPage() {
     return (
       <div className="flex min-h-[calc(100vh-56px)] items-center justify-center">
         <div className="flex items-center gap-3 text-sm text-[#6B7280]">
-          <svg
-            className="h-5 w-5 animate-spin"
-            fill="none"
-            viewBox="0 0 24 24"
-          >
+          <svg className="h-5 w-5 animate-spin" fill="none" viewBox="0 0 24 24">
             <circle
               className="opacity-25"
               cx="12"

--- a/frontend/src/app/api/admin/prompts/route.ts
+++ b/frontend/src/app/api/admin/prompts/route.ts
@@ -129,9 +129,6 @@ export async function POST(req: Request) {
     return Response.json({ success: true, prompts });
   } catch (err) {
     console.error("Failed to write prompts file:", err);
-    return Response.json(
-      { error: "Failed to save prompts" },
-      { status: 500 },
-    );
+    return Response.json({ error: "Failed to save prompts" }, { status: 500 });
   }
 }

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -408,26 +408,12 @@ export default function ChatPage() {
 
   const [input, setInput] = useState("");
   const [sidebarOpen, setSidebarOpen] = useState(true);
-  const [conversations, setConversations] = useState<ConversationMeta[]>([]);
-  const [activeConversationId, setActiveConversationId] = useState("");
+  const [conversations, setConversations] = useState(loadConversations);
+  const [activeConversationId, setActiveConversationId] = useState(generateId);
   const [restoredMessages, setRestoredMessages] = useState<StoredMessage[]>([]);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const initRef = useRef(false);
-
-  // Initialize on mount
-  useEffect(() => {
-    if (initRef.current) return;
-    initRef.current = true;
-
-    const convos = loadConversations();
-    setConversations(convos);
-
-    // Start a new conversation
-    const newId = generateId();
-    setActiveConversationId(newId);
-  }, []);
 
   // Auto-scroll on new messages
   useEffect(() => {
@@ -481,11 +467,9 @@ export default function ChatPage() {
 
     saveMessages(activeConversationId, stored);
 
-    // Update conversation meta — use in-memory state, not redundant localStorage read
-    const allConvos = [...conversations];
-    const existingIdx = allConvos.findIndex(
-      (c) => c.id === activeConversationId,
-    );
+    // Update conversation meta via functional updater (avoids stale closure
+    // and the "setState in effect" lint rule, since the update is derived
+    // from previous state rather than called unconditionally).
     const firstUserMsg = messages.find((m) => m.role === "user");
     const title = firstUserMsg
       ? (
@@ -502,20 +486,29 @@ export default function ChatPage() {
       messageCount: messages.length,
     };
 
-    if (existingIdx >= 0) {
-      allConvos[existingIdx] = meta;
-    } else {
-      allConvos.unshift(meta);
-    }
+    // Sync conversation list to localStorage when AI stream completes.
+    // This is a response to an external system (AI SDK), not a cascading render.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setConversations((prev) => {
+      const allConvos = [...prev];
+      const existingIdx = allConvos.findIndex(
+        (c) => c.id === activeConversationId,
+      );
 
-    // Trim to max
-    while (allConvos.length > MAX_CONVERSATIONS) {
-      const removed = allConvos.pop();
-      if (removed) deleteConversation(removed.id);
-    }
+      if (existingIdx >= 0) {
+        allConvos[existingIdx] = meta;
+      } else {
+        allConvos.unshift(meta);
+      }
 
-    saveConversations(allConvos);
-    setConversations(allConvos);
+      while (allConvos.length > MAX_CONVERSATIONS) {
+        const removed = allConvos.pop();
+        if (removed) deleteConversation(removed.id);
+      }
+
+      saveConversations(allConvos);
+      return allConvos;
+    });
   }, [status, messages, activeConversationId]);
 
   const isLoading = status === "streaming" || status === "submitted";

--- a/frontend/src/app/products/[id]/ProductDetail.tsx
+++ b/frontend/src/app/products/[id]/ProductDetail.tsx
@@ -61,9 +61,7 @@ function ImageGallery({ images }: { images: StrapiMedia[] }) {
               )}
             >
               <Image
-                src={
-                  img.formats?.thumbnail?.url || img.url
-                }
+                src={img.formats?.thumbnail?.url || img.url}
                 alt=""
                 fill
                 sizes="64px"
@@ -118,7 +116,8 @@ export function ProductDetail({ product }: ProductDetailProps) {
       }
       return `${formatPrice(product.price_min)} - ${formatPrice(product.price_max)}`;
     }
-    if (product.price_min != null) return `from ${formatPrice(product.price_min)}`;
+    if (product.price_min != null)
+      return `from ${formatPrice(product.price_min)}`;
     return null;
   })();
 
@@ -259,7 +258,10 @@ export function ProductDetail({ product }: ProductDetailProps) {
                         {product.price_tiers!.some((t) => t.buying_price) && (
                           <td className="px-3 py-2 text-sols-muted">
                             {tier.buying_price
-                              ? formatPrice(tier.buying_price, tier.currency || "EUR")
+                              ? formatPrice(
+                                  tier.buying_price,
+                                  tier.currency || "EUR",
+                                )
                               : "-"}
                           </td>
                         )}
@@ -288,9 +290,12 @@ export function ProductDetail({ product }: ProductDetailProps) {
                   <dt className="text-sols-muted">Dimensions</dt>
                   <dd className="font-medium text-sols-dark">
                     {[
-                      product.dimensions.length && `L: ${product.dimensions.length}`,
-                      product.dimensions.width && `W: ${product.dimensions.width}`,
-                      product.dimensions.height && `H: ${product.dimensions.height}`,
+                      product.dimensions.length &&
+                        `L: ${product.dimensions.length}`,
+                      product.dimensions.width &&
+                        `W: ${product.dimensions.width}`,
+                      product.dimensions.height &&
+                        `H: ${product.dimensions.height}`,
                     ]
                       .filter(Boolean)
                       .join(" x ")}{" "}
@@ -315,22 +320,24 @@ export function ProductDetail({ product }: ProductDetailProps) {
                   </dd>
                 </>
               )}
-              {product.available_colors && product.available_colors.length > 0 && (
-                <>
-                  <dt className="text-sols-muted">Colors</dt>
-                  <dd className="font-medium text-sols-dark">
-                    {product.available_colors.length}
-                  </dd>
-                </>
-              )}
-              {product.available_sizes && product.available_sizes.length > 0 && (
-                <>
-                  <dt className="text-sols-muted">Sizes</dt>
-                  <dd className="font-medium text-sols-dark">
-                    {product.available_sizes.join(", ")}
-                  </dd>
-                </>
-              )}
+              {product.available_colors &&
+                product.available_colors.length > 0 && (
+                  <>
+                    <dt className="text-sols-muted">Colors</dt>
+                    <dd className="font-medium text-sols-dark">
+                      {product.available_colors.length}
+                    </dd>
+                  </>
+                )}
+              {product.available_sizes &&
+                product.available_sizes.length > 0 && (
+                  <>
+                    <dt className="text-sols-muted">Sizes</dt>
+                    <dd className="font-medium text-sols-dark">
+                      {product.available_sizes.join(", ")}
+                    </dd>
+                  </>
+                )}
             </dl>
           </div>
 

--- a/frontend/src/app/products/[id]/page.tsx
+++ b/frontend/src/app/products/[id]/page.tsx
@@ -59,9 +59,7 @@ export default async function ProductPage({ params }: PageProps) {
   if (!product) {
     return (
       <div className="flex min-h-[60vh] flex-col items-center justify-center px-4 text-center">
-        <h1 className="text-2xl font-bold text-sols-dark">
-          Product not found
-        </h1>
+        <h1 className="text-2xl font-bold text-sols-dark">Product not found</h1>
         <p className="mt-2 text-sols-muted">
           The product you are looking for does not exist or has been removed.
         </p>

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -3,15 +3,11 @@
 import { useEffect, useRef, useState } from "react";
 import { useChat } from "@ai-sdk/react";
 import { useChatContext } from "@/lib/chat-context";
-import { cn, formatPrice } from "@/lib/utils";
-import type {
-  FacetDistribution,
-  MeilisearchProduct,
-  SearchParams,
-} from "@/lib/types";
+import { cn } from "@/lib/utils";
+import type { FacetDistribution, SearchParams } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
-// Inline product card for chat results (slim preview)
+// Tool output types
 // ---------------------------------------------------------------------------
 
 interface SlimProduct {
@@ -25,44 +21,6 @@ interface SlimProduct {
   sizes?: string[];
   category?: string;
 }
-
-function ChatProductCard({ product }: { product: SlimProduct }) {
-  return (
-    <a
-      href={`/products/${product.id}`}
-      className="flex gap-3 rounded-lg border border-sols-border/50 bg-white p-2 transition-colors hover:bg-sols-light-gray/50"
-    >
-      <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-md bg-sols-light-gray p-1">
-        <svg
-          className="h-6 w-6 text-sols-muted"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={1}
-        >
-          <path d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
-        </svg>
-      </div>
-      <div className="min-w-0 flex-1">
-        <p className="truncate text-xs font-semibold text-sols-dark">
-          {product.name}
-        </p>
-        {product.brand && (
-          <p className="text-[10px] text-sols-muted">{product.brand}</p>
-        )}
-        {product.price_min != null && (
-          <p className="text-xs font-semibold text-sols-accent">
-            {formatPrice(product.price_min, product.currency)}
-          </p>
-        )}
-      </div>
-    </a>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Tool output types
-// ---------------------------------------------------------------------------
 
 interface ToolOutput {
   filters_applied?: Record<string, unknown>;

--- a/frontend/src/components/ColorSwatch.tsx
+++ b/frontend/src/components/ColorSwatch.tsx
@@ -39,16 +39,11 @@ export function ColorSwatch({
         "relative shrink-0 rounded-full transition-all",
         sizeMap[size],
         isWhiteish && "border border-sols-border",
-        selected &&
-          "ring-2 ring-sols-accent ring-offset-1 ring-offset-white",
+        selected && "ring-2 ring-sols-accent ring-offset-1 ring-offset-white",
         onClick && "cursor-pointer hover:scale-110",
         !onClick && "cursor-default",
       )}
-      style={
-        isGrad
-          ? { background: color }
-          : { backgroundColor: color }
-      }
+      style={isGrad ? { background: color } : { backgroundColor: color }}
     >
       <span className="sr-only">{colorName}</span>
     </button>

--- a/frontend/src/components/ProductGrid.tsx
+++ b/frontend/src/components/ProductGrid.tsx
@@ -23,10 +23,7 @@ function SkeletonCard() {
         <div className="h-4 w-20 rounded bg-sols-mid-gray" />
         <div className="mt-2 flex gap-1">
           {[...Array(4)].map((_, i) => (
-            <div
-              key={i}
-              className="h-4 w-4 rounded-full bg-sols-mid-gray"
-            />
+            <div key={i} className="h-4 w-4 rounded-full bg-sols-mid-gray" />
           ))}
         </div>
       </div>
@@ -34,7 +31,12 @@ function SkeletonCard() {
   );
 }
 
-export function ProductGrid({ products, total, loading, chatOpen = false }: ProductGridProps) {
+export function ProductGrid({
+  products,
+  total,
+  loading,
+  chatOpen = false,
+}: ProductGridProps) {
   const gridCols = chatOpen
     ? "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
     : "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4";

--- a/frontend/src/components/filters/BrandFilter.tsx
+++ b/frontend/src/components/filters/BrandFilter.tsx
@@ -55,7 +55,9 @@ export function BrandFilter({ facets, selected, onChange }: BrandFilterProps) {
               key={name}
               className={cn(
                 "flex cursor-pointer items-center gap-2 rounded px-1.5 py-1 text-xs transition-colors",
-                isSelected ? "bg-sols-light-gray" : "hover:bg-sols-light-gray/60",
+                isSelected
+                  ? "bg-sols-light-gray"
+                  : "hover:bg-sols-light-gray/60",
               )}
             >
               <input
@@ -89,7 +91,9 @@ export function BrandFilter({ facets, selected, onChange }: BrandFilterProps) {
       )}
 
       {search && sorted.length === 0 && (
-        <p className="text-xs text-sols-muted">No brands match &quot;{search}&quot;</p>
+        <p className="text-xs text-sols-muted">
+          No brands match &quot;{search}&quot;
+        </p>
       )}
     </div>
   );

--- a/frontend/src/components/filters/CategoryFilter.tsx
+++ b/frontend/src/components/filters/CategoryFilter.tsx
@@ -61,9 +61,7 @@ function CategoryNodeItem({
   onChange: (v: string) => void;
   depth?: number;
 }) {
-  const [expanded, setExpanded] = useState(
-    selected.startsWith(node.fullPath),
-  );
+  const [expanded, setExpanded] = useState(selected.startsWith(node.fullPath));
   const isSelected = selected === node.fullPath;
   const hasChildren = node.children.length > 0;
 
@@ -133,9 +131,7 @@ export function CategoryFilter({
   const tree = useMemo(() => buildTree(facets || {}), [facets]);
 
   if (tree.length === 0) {
-    return (
-      <p className="text-xs text-sols-muted">No categories available</p>
-    );
+    return <p className="text-xs text-sols-muted">No categories available</p>;
   }
 
   return (


### PR DESCRIPTION
ESLint fixes:
- chat/page.tsx: replace mount effect with lazy state initializers, use functional setConversations updater in persist effect
- ChatPanel.tsx: remove unused MeilisearchProduct import and ChatProductCard function (dead code from catalog refactor)

Prettier: format 8 files that had drifted from code style

Documentation updates:
- ARCHITECTURE.md: add /chat page, chat-bot route, chat-search module
- DECISIONS.md: add standalone chatbot decision entry
- STACK.md: fix stale versions (React 19, Next.js 16, Turbopack), update deployment target from Vercel to Coolify
- GOTCHAS.md: add AI SDK v6 useChat transport, tool part states, and React.memo + useMemo ordering gotchas