### PR TITLE
fix: hydrate chat conversations client-side to avoid SSR mismatch

### DIFF
--- a/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/backend/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2026-04-02T09:18:29.038Z"
+    "x-generation-date": "2026-04-05T10:59:01.316Z"
   },
   "x-strapi-config": {
     "plugins": [

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -408,9 +408,21 @@ export default function ChatPage() {
 
   const [input, setInput] = useState("");
   const [sidebarOpen, setSidebarOpen] = useState(true);
-  const [conversations, setConversations] = useState(loadConversations);
-  const [activeConversationId, setActiveConversationId] = useState(generateId);
+  const [conversations, setConversations] = useState<ConversationMeta[]>([]);
+  const [activeConversationId, setActiveConversationId] = useState("");
   const [restoredMessages, setRestoredMessages] = useState<StoredMessage[]>([]);
+  const [hydrated, setHydrated] = useState(false);
+
+  // Hydrate from localStorage after mount to avoid SSR mismatch.
+  // setState in effect is intentional — localStorage is an external store
+  // that is only available on the client.
+  useEffect(() => {
+    /* eslint-disable react-hooks/set-state-in-effect */
+    setConversations(loadConversations());
+    setActiveConversationId(generateId());
+    /* eslint-enable react-hooks/set-state-in-effect */
+    setHydrated(true);
+  }, []);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -430,7 +442,12 @@ export default function ChatPage() {
 
   // Persist messages to localStorage when stream completes
   useEffect(() => {
-    if (status !== "ready" || messages.length === 0 || !activeConversationId)
+    if (
+      !hydrated ||
+      status !== "ready" ||
+      messages.length === 0 ||
+      !activeConversationId
+    )
       return;
 
     const stored: StoredMessage[] = messages.map((msg) => {
@@ -509,7 +526,7 @@ export default function ChatPage() {
       saveConversations(allConvos);
       return allConvos;
     });
-  }, [status, messages, activeConversationId]);
+  }, [hydrated, status, messages, activeConversationId]);
 
   const isLoading = status === "streaming" || status === "submitted";
 


### PR DESCRIPTION
## Summary
- Move `loadConversations()` and `generateId()` out of `useState` initializers and into a `useEffect`, so the client hydrates from `localStorage` after mount instead of during SSR. This eliminates the server/client state mismatch on `/chat`.
- Gate the persistence effect on a new `hydrated` flag so messages aren't written back with the default empty state before hydration completes.

## Test plan
- [ ] Load `/chat` in a fresh browser — no hydration warning in console
- [ ] Start a conversation, reload the page — messages restore from localStorage
- [ ] Open multiple tabs, verify conversation list stays consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)