### PR TITLE
fix: restore frontend Dockerfile for Next.js 16 Coolify deploy

### DIFF
--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -88,7 +88,7 @@ services:
   # BullMQ automatically distributes jobs across all worker instances
 
   # ============================================
-  # Frontend (React + Nginx)
+  # Frontend (Next.js 16 standalone server)
   # ============================================
   frontend:
     build:
@@ -109,17 +109,18 @@ services:
       - "traefik.http.routers.frontend-https.entrypoints=https"
       - "traefik.http.routers.frontend-https.tls=true"
       - "traefik.http.routers.frontend-https.tls.certresolver=letsencrypt"
-      - "traefik.http.services.frontend.loadbalancer.server.port=80"
+      - "traefik.http.services.frontend.loadbalancer.server.port=3000"
 
     expose:
-      - "80"
+      - "3000"
 
+    # Alpine base has wget but not curl. Any HTTP response means the server is up.
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:80/"]
+      test: ["CMD", "sh", "-c", "wget --quiet --tries=1 --spider --server-response http://127.0.0.1:3000/ 2>&1 | grep -q 'HTTP/'"]
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 30s
+      start_period: 60s
 
     logging:
       driver: "json-file"

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,17 @@
+node_modules
+.next
+.git
+.gitignore
+.env
+.env.local
+.env.*.local
+.vercel
+.turbo
+*.log
+npm-debug.log*
+README.md
+CLAUDE.md
+AGENTS.md
+Dockerfile
+.dockerignore
+tsconfig.tsbuildinfo

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,58 @@
+# syntax=docker/dockerfile:1.6
+# Multi-stage build for Next.js 16 production deployment.
+# Relies on `output: "standalone"` in next.config.ts so the runner image
+# only needs the traced server bundle, not the full node_modules tree.
+
+FROM node:22-alpine AS base
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+
+# ============================================
+# Dependencies — install all deps (including devDeps for the build)
+# ============================================
+FROM base AS deps
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# ============================================
+# Builder — compile Next.js with standalone output
+# ============================================
+FROM base AS builder
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN npm run build
+
+# ============================================
+# Production runner — minimal image that serves the standalone bundle
+# ============================================
+FROM base AS production
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+# Non-root user for the runtime
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+# Public static assets (served by the standalone server)
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+
+# Standalone server + traced node_modules, plus the static asset directory
+# that `server.js` expects at ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+# Alpine has wget but not curl; probe the root path for any HTTP response.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+  CMD wget --quiet --tries=1 --spider --server-response http://127.0.0.1:3000/ 2>&1 | grep -q "HTTP/" || exit 1
+
+CMD ["node", "server.js"]

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,6 +1,10 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  // Produce a self-contained production bundle at .next/standalone so the
+  // Docker image can run `node server.js` without the full node_modules tree.
+  output: "standalone",
+
   async rewrites() {
     return {
       // beforeFiles rewrites are checked before pages/public files and after


### PR DESCRIPTION
## Summary
Develop deploys fail with `failed to read dockerfile: open Dockerfile: no such file or directory` because PR #27 removed the old Vite+Nginx `frontend/Dockerfile`, but `docker-compose.coolify.yml` still references it.

## Changes
- **`frontend/next.config.ts`** — add `output: "standalone"` so Next.js emits a minimal self-contained server bundle.
- **`frontend/Dockerfile`** (new) — multi-stage build on `node:22-alpine` (deps → builder → production). Copies `.next/standalone`, `.next/static`, `public`. Runs `node server.js` as non-root user on port 3000.
- **`frontend/.dockerignore`** (new) — keeps the build context small.
- **`docker-compose.coolify.yml`** — frontend service updated for Next.js: port 80 → 3000 (traefik + expose), curl healthcheck → wget (alpine has no curl), `start_period` 30s → 60s, refresh stale "React + Nginx" comment.

## Verified
- `docker build --target production -f frontend/Dockerfile frontend/` succeeds locally.
- `docker run -p 3099:3000` starts cleanly, container responds `HTTP/1.1 200 OK` on `/`.

## Follow-up (not in this PR)
`next.config.ts` rewrites hardcode `http://localhost:1337`. Paths owned by Route Handlers (`/api/chat`, `/api/chat-bot`, `/api/admin/*`) are fine because they never hit the rewrite. Any other `/api/*` fallback will 502 in production. Should become an env-driven `STRAPI_INTERNAL_URL` in a separate PR.

## Test plan
- [ ] Coolify deploy from `develop` passes the build step
- [ ] Frontend container reports healthy within `start_period`
- [ ] `atlaspim.solslab.dev` loads the Next.js catalog page
- [ ] `/chat` page loads
- [ ] Product search still reaches Strapi (verify via a product query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)