### PR TITLE
fix: parameterize Strapi proxy URL in Next.js rewrites

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -21,6 +21,13 @@ FROM base AS builder
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
+# next.config.ts reads STRAPI_PROXY_URL at build time and bakes it into the
+# rewrites config inside the standalone server bundle. Must be passed as a
+# build arg from Coolify (or `docker build --build-arg`); falls back to the
+# local dev URL so `docker build` without an arg still succeeds.
+ARG STRAPI_PROXY_URL=http://localhost:1337
+ENV STRAPI_PROXY_URL=$STRAPI_PROXY_URL
+
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,5 +1,12 @@
 import type { NextConfig } from "next";
 
+// Where to proxy /api/* requests that don't have a local Route Handler.
+// Read at build time and serialized into the server bundle — must therefore
+// be passed as a Docker build arg in production (see frontend/Dockerfile).
+// Defaults to the local Strapi dev server for `npm run dev`.
+const STRAPI_PROXY_URL =
+  process.env.STRAPI_PROXY_URL || "http://localhost:1337";
+
 const nextConfig: NextConfig = {
   // Produce a self-contained production bundle at .next/standalone so the
   // Docker image can run `node server.js` without the full node_modules tree.
@@ -18,7 +25,7 @@ const nextConfig: NextConfig = {
               key: "x-rewrite-to-strapi",
             },
           ],
-          destination: "http://localhost:1337/api/:path*",
+          destination: `${STRAPI_PROXY_URL}/api/:path*`,
         },
       ],
       afterFiles: [],
@@ -29,7 +36,7 @@ const nextConfig: NextConfig = {
       fallback: [
         {
           source: "/api/:path*",
-          destination: "http://localhost:1337/api/:path*",
+          destination: `${STRAPI_PROXY_URL}/api/:path*`,
         },
       ],
     };


### PR DESCRIPTION
## Summary
Follow-up to #37. The frontend's client code calls `/api/products/search`, `/api/categories`, `/api/suppliers`, and `/api/products/:id` — none of which have local Route Handlers. They fall through to the `next.config.ts` rewrite, which previously hardcoded `http://localhost:1337`.

In a production Docker container, `localhost` is the frontend container itself, so those calls would 502 against any Coolify deploy (new or old).

## Changes
- **`frontend/next.config.ts`** — read `STRAPI_PROXY_URL` from env (defaults to `http://localhost:1337` for local dev), use it in both `beforeFiles` and `fallback` rewrite destinations.
- **`frontend/Dockerfile`** — `ARG STRAPI_PROXY_URL` + `ENV` in the builder stage, before `RUN npm run build`. Next.js reads `next.config.ts` at build time and serializes the rewrites config into the standalone server bundle, so this must be a build arg, not just a runtime env var.

## Verified
- `docker build --build-arg STRAPI_PROXY_URL=https://cms.atlas.solslab.dev` succeeds.
- Inside the produced image, `.next/routes-manifest.json` and `.next/required-server-files.json` both contain `https://cms.atlas.solslab.dev/api/:path*` as the rewrite destination.
- The only remaining `localhost:1337` reference is the runtime fallback for `STRAPI_INTERNAL_URL` in server-side code (`products/[id]/page.tsx`, `lib/chat-search.ts`), which is correct — that's read at container start, not build time.

## Deployment note
Coolify consumers of this change must set `STRAPI_PROXY_URL` as **Available at Buildtime** so it gets passed as a build arg. For the new staging, the value should be `https://cms.atlas.solslab.dev`.

## Test plan
- [ ] PR builds green
- [ ] New Coolify frontend app builds successfully with `STRAPI_PROXY_URL=https://cms.atlas.solslab.dev` as buildtime var
- [ ] `atlas.solslab.dev` catalog page loads products (validates the rewrite works end-to-end)
- [ ] Old server (still using `docker-compose.coolify.yml`) continues to work unchanged — the build arg has a localhost fallback, but that was already broken on the old server for the same reason; this PR doesn't regress it

🤖 Generated with [Claude Code](https://claude.com/claude-code)