### PR TITLE
fix: remove dead workers stage from backend Dockerfile, probe /api/health

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -66,19 +66,10 @@ EXPOSE 1337
 ENV NODE_ENV=production
 ENV STRAPI_TELEMETRY_DISABLED=true
 
-# Health check - waits for Strapi to fully start (90s) then checks connectivity
-# Using 127.0.0.1 to avoid IPv6 issues, checking any response (including 404) means server is up
-HEALTHCHECK --interval=30s --timeout=10s --start-period=90s --retries=3 \
-  CMD wget --quiet --tries=1 --spider --server-response http://127.0.0.1:1337/ 2>&1 | grep -q "HTTP/" || exit 1
+# Health check - waits 120s for first boot (fresh DB schema creation, supplier
+# bootstrap, worker startup), then probes /api/health for a strict 200 OK.
+# Using 127.0.0.1 to avoid IPv6 issues.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
+  CMD wget --quiet --tries=1 --spider --server-response http://127.0.0.1:1337/api/health 2>&1 | grep -q "200 OK" || exit 1
 
 CMD ["npm", "start"]
-
-# Workers stage - for running BullMQ workers separately
-FROM production AS workers
-WORKDIR /app
-
-# Workers don't need HTTP port exposure
-# Remove healthcheck since workers don't have HTTP endpoint
-
-# Run the standalone worker process (note: path includes 'src/')
-CMD ["node", "dist/src/workers/start-workers.js"]


### PR DESCRIPTION
## Problem

The new Coolify backend app crash-loops on deploy with:

\`\`\`
Error: Cannot find module '/app/dist/src/workers/start-workers.js'
\`\`\`

### Why

\`backend/Dockerfile\` had a dead \`workers\` multi-stage target after \`production\`:

\`\`\`dockerfile
# Workers stage - for running BullMQ workers separately
FROM production AS workers
WORKDIR /app
CMD [\"node\", \"dist/src/workers/start-workers.js\"]
\`\`\`

Three problems with this stage:
1. **It's the last stage in the file.** Docker's default behavior without \`--target\` is to build the last stage. The old server hid this because \`docker-compose.coolify.yml\` set \`target: production\` explicitly. The new two-app Coolify setup uses the Dockerfile directly with no target, so Docker fell into the trap.
2. **The CMD path is wrong.** It references \`dist/src/workers/start-workers.js\`, but the \`production\` stage it inherits from copies the built JS to \`./src\`, not \`./dist/src\`. The file doesn't exist in the image.
3. **It's dead code anyway.** The comment in \`docker-compose.coolify.yml\` says:
   > *BullMQ Workers - INTEGRATED INTO STRAPI. Workers run automatically inside the Strapi container via src/index.ts bootstrap. No separate workers service needed.*

## Fix

Delete the dead stage. \`production\` becomes the final stage, Docker default picks it up, no Coolify config needed to remember.

## Also in this PR: tighten the HEALTHCHECK

The Dockerfile's existing HEALTHCHECK probed \`/\` with a loose \`grep \"HTTP/\"\` pattern, which would match *any* HTTP response — including 404s or 500s from a broken Strapi.

The project already ships a public \`/api/health\` endpoint (see \`backend/src/api/health/\`) that returns a strict 200 with a small JSON payload. Switching the HEALTHCHECK to probe that endpoint with a strict \`grep \"200 OK\"\` gives a meaningful signal.

Also bumped \`start_period\` from 90s to 120s — first-boot on a fresh Postgres runs schema migrations + supplier bootstrap + worker init, which is slower than subsequent boots.

## Verified

The change is a 9-line deletion of dead code plus a one-line probe change. Not re-verified with a full local build (frontend was built with the same base pattern recently in #37 and #38).

## Coolify UI healthcheck settings (for the new backend app)

| Field | Value |
|---|---|
| Enabled | Yes |
| Scheme | http |
| Port | 1337 |
| Path | \`/api/health\` |
| Method | GET |
| Return code | 200 |
| Interval | 30 |
| Timeout | 10 |
| Retries | 3 |
| Start period | 120 |

## Test plan
- [ ] PR builds green
- [ ] Backend app on Coolify deploys successfully, container reports healthy
- [ ] \`curl https://cms.atlas.solslab.dev/api/health\` returns \`{\"status\":\"ok\",...}\`
- [ ] Strapi admin panel loads at \`/admin\`
- [ ] Queue workers start (visible in logs: \`✅ Started 4 workers\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)