### PR TITLE
fix: force devDependencies install in frontend Dockerfile deps stage

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,7 +12,13 @@ WORKDIR /app
 # ============================================
 FROM base AS deps
 COPY package.json package-lock.json ./
-RUN npm ci
+# --include=dev forces devDependencies to install even if NODE_ENV=production
+# leaks into the build environment (e.g. via a Coolify build-arg).
+# The `builder` stage below needs devDeps like @tailwindcss/postcss and
+# typescript to run `next build`. DevDeps never reach the final image —
+# the production stage copies from `.next/standalone`, which only contains
+# runtime deps traced by Next.js.
+RUN npm ci --include=dev
 
 # ============================================
 # Builder — compile Next.js with standalone output


### PR DESCRIPTION
## Problem

Frontend Coolify deploy fails during \`next build\`:

\`\`\`
Error: Cannot find module '@tailwindcss/postcss'
Require stack:
- /app/.next/build/chunks/[root-of-the-server]__0d-m0h0._.js
- /app/.next/build/chunks/[turbopack]_runtime.js
- /app/.next/build/postcss.js
\`\`\`

## Root cause

npm treats \`NODE_ENV=production\` as an implicit \`--omit=dev\`, skipping devDependencies regardless of the \`npm ci\` command-line flags. For Next.js we need \`NODE_ENV=production\` as a buildtime env var in Coolify so \`next build\` produces a production bundle — but that same buildtime arg leaks into the earlier \`deps\` stage where \`npm ci\` runs, which is what broke the build.

Evidence from the failing log:

\`\`\`
#14 [deps 2/2] RUN npm ci
#14 11.96 added 47 packages, and audited 48 packages in 12s
\`\`\`

47 packages means devDeps were skipped. With \`--include=dev\`, a clean local build installs **385 packages**.

Backend was not affected because its \`deps\` stage uses \`npm ci --only=production\` intentionally (only installs prod deps there; the \`builder\` stage does its own separate \`npm ci\` with devDeps).

## Fix

Add \`--include=dev\` to \`npm ci\` in the frontend \`deps\` stage so devDependencies install regardless of any \`NODE_ENV\` buildtime arg. DevDeps never reach the final image — the \`production\` stage copies only from \`.next/standalone\`, which contains only runtime deps traced by Next.js.

## Verified

\`\`\`
docker build --no-cache -f frontend/Dockerfile \\
  --build-arg STRAPI_PROXY_URL=https://cms.atlas.solslab.dev \\
  --build-arg NODE_ENV=production \\
  --target production frontend/
\`\`\`

Output:

\`\`\`
#12 [deps 2/2] RUN npm ci --include=dev
#12 30.97 added 385 packages, and audited 386 packages in 31s
\`\`\`

Full build succeeds end-to-end, produces working image.

## Alternative fix (not chosen)

Could have told users to uncheck \"Available at Buildtime\" for \`NODE_ENV\` in Coolify — the Dockerfile's builder stage already sets \`ENV NODE_ENV=production\` before \`npm run build\`, so the buildtime arg is redundant. But making the Dockerfile robust against the misconfiguration is better than documenting it as a footgun.

## Test plan
- [ ] PR builds green
- [ ] Coolify frontend deploy succeeds with \`NODE_ENV\` marked as buildtime
- [ ] Frontend container starts, Next.js ready on :3000
- [ ] \`atlas.solslab.dev\` loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)