### PR TITLE
fix: remove stale meilisearch-sync references from admin Queue Dashboard

### DIFF
--- a/backend/src/admin/api/queueManager.ts
+++ b/backend/src/admin/api/queueManager.ts
@@ -29,7 +29,6 @@ export interface AllQueueStats {
   supplierSync: QueueStats;
   productFamily: QueueStats;
   imageUpload: QueueStats;
-  meilisearchSync: QueueStats;
 }
 
 export interface WorkerStatus {

--- a/backend/src/admin/pages/QueueManagement/QueueCard.tsx
+++ b/backend/src/admin/pages/QueueManagement/QueueCard.tsx
@@ -9,7 +9,7 @@ import { Trash } from '@strapi/icons';
 import type { QueueStats } from '../../api/queueManager';
 
 interface QueueCardProps {
-  stats: QueueStats;
+  stats: QueueStats | undefined;
   onPause: () => void;
   onResume: () => void;
   onClean: () => void;
@@ -23,6 +23,11 @@ const QueueCard: React.FC<QueueCardProps> = ({
   onClean,
   onRetryFailed,
 }) => {
+  // Defensive: the backend may return fewer queues than the UI expects if
+  // queues are added/removed without updating both sides. Render nothing
+  // rather than crashing the whole admin page.
+  if (!stats) return null;
+
   const isPaused = stats.paused || false;
 
   // Get queue display name
@@ -31,7 +36,6 @@ const QueueCard: React.FC<QueueCardProps> = ({
       'supplier-sync': 'Supplier Sync',
       'product-family': 'Product Family',
       'image-upload': 'Image Upload',
-      'meilisearch-sync': 'Meilisearch Sync',
     };
     return names[queueName] || queueName;
   };

--- a/backend/src/admin/pages/QueueManagement/index.tsx
+++ b/backend/src/admin/pages/QueueManagement/index.tsx
@@ -347,28 +347,19 @@ const QueueManagement: React.FC = () => {
             </Grid.Root>
           </Box>
 
-          {/* Processing Queues */}
+          {/* Image Processing */}
           <Box paddingBottom={4}>
             <Typography variant="sigma" textColor="neutral600" paddingBottom={2}>
-              Processing & Storage
+              Image Processing
             </Typography>
             <Grid.Root gap={4}>
-              <Grid.Item col={4} s={12}>
+              <Grid.Item col={12} s={12}>
                 <QueueCard
                   stats={allStats.imageUpload}
                   onPause={() => handlePauseQueue('image-upload')}
                   onResume={() => handleResumeQueue('image-upload')}
                   onClean={() => handleCleanQueue('image-upload')}
                   onRetryFailed={() => handleRetryFailedJobs('image-upload')}
-                />
-              </Grid.Item>
-              <Grid.Item col={4} s={12}>
-                <QueueCard
-                  stats={allStats.meilisearchSync}
-                  onPause={() => handlePauseQueue('meilisearch-sync')}
-                  onResume={() => handleResumeQueue('meilisearch-sync')}
-                  onClean={() => handleCleanQueue('meilisearch-sync')}
-                  onRetryFailed={() => handleRetryFailedJobs('meilisearch-sync')}
                 />
               </Grid.Item>
             </Grid.Root>
@@ -400,7 +391,6 @@ const QueueManagement: React.FC = () => {
                 <SingleSelectOption value="supplier-sync">Supplier Sync</SingleSelectOption>
                 <SingleSelectOption value="product-family">Product Family</SingleSelectOption>
                 <SingleSelectOption value="image-upload">Image Upload</SingleSelectOption>
-                <SingleSelectOption value="meilisearch-sync">Meilisearch Sync</SingleSelectOption>
               </SingleSelect>
 
               <SingleSelect

--- a/backend/src/api/queue-manager/controllers/queue-manager.ts
+++ b/backend/src/api/queue-manager/controllers/queue-manager.ts
@@ -13,10 +13,10 @@ export default ({
   async getStats(ctx) {
     try {
       const { queue } = ctx.params;
-      const queueName = queue as 'supplier-sync' | 'product-family' | 'image-upload' | 'meilisearch-sync' | undefined;
+      const queueName = queue as 'supplier-sync' | 'product-family' | 'image-upload' | undefined;
 
       // Validate queue name if provided
-      if (queueName && !['supplier-sync', 'product-family', 'image-upload', 'meilisearch-sync'].includes(queueName as string)) {
+      if (queueName && !['supplier-sync', 'product-family', 'image-upload'].includes(queueName as string)) {
         return ctx.badRequest('Invalid queue name');
       }
 
@@ -58,7 +58,7 @@ export default ({
       const { state = 'waiting', page = '1', pageSize = '25', search } = ctx.query;
 
       // Validate queue name
-      if (!['supplier-sync', 'product-family', 'image-upload', 'meilisearch-sync'].includes(queue)) {
+      if (!['supplier-sync', 'product-family', 'image-upload'].includes(queue)) {
         return ctx.badRequest('Invalid queue name');
       }
 
@@ -106,7 +106,7 @@ export default ({
       const { queue, jobId } = ctx.params;
 
       // Validate queue name
-      if (!['supplier-sync', 'product-family', 'image-upload', 'meilisearch-sync'].includes(queue)) {
+      if (!['supplier-sync', 'product-family', 'image-upload'].includes(queue)) {
         return ctx.badRequest('Invalid queue name');
       }
 
@@ -134,7 +134,7 @@ export default ({
       const { queue, jobId } = ctx.params;
 
       // Validate queue name
-      if (!['supplier-sync', 'product-family', 'image-upload', 'meilisearch-sync'].includes(queue)) {
+      if (!['supplier-sync', 'product-family', 'image-upload'].includes(queue)) {
         return ctx.badRequest('Invalid queue name');
       }
 
@@ -163,7 +163,7 @@ export default ({
       const { limit = '100' } = ctx.request.body as any;
 
       // Validate queue name
-      if (!['supplier-sync', 'product-family', 'image-upload', 'meilisearch-sync'].includes(queue)) {
+      if (!['supplier-sync', 'product-family', 'image-upload'].includes(queue)) {
         return ctx.badRequest('Invalid queue name');
       }
 
@@ -193,7 +193,7 @@ export default ({
       const { queue, jobId } = ctx.params;
 
       // Validate queue name
-      if (!['supplier-sync', 'product-family', 'image-upload', 'meilisearch-sync'].includes(queue)) {
+      if (!['supplier-sync', 'product-family', 'image-upload'].includes(queue)) {
         return ctx.badRequest('Invalid queue name');
       }
 
@@ -221,7 +221,7 @@ export default ({
       const { queue } = ctx.params;
 
       // Validate queue name
-      if (!['supplier-sync', 'product-family', 'image-upload', 'meilisearch-sync'].includes(queue)) {
+      if (!['supplier-sync', 'product-family', 'image-upload'].includes(queue)) {
         return ctx.badRequest('Invalid queue name');
       }
 
@@ -245,7 +245,7 @@ export default ({
       const { queue } = ctx.params;
 
       // Validate queue name
-      if (!['supplier-sync', 'product-family', 'image-upload', 'meilisearch-sync'].includes(queue)) {
+      if (!['supplier-sync', 'product-family', 'image-upload'].includes(queue)) {
         return ctx.badRequest('Invalid queue name');
       }
 
@@ -270,7 +270,7 @@ export default ({
       const { grace = 3600000, status = 'completed' } = ctx.request.body as any;
 
       // Validate queue name
-      if (!['supplier-sync', 'product-family', 'image-upload', 'meilisearch-sync'].includes(queue)) {
+      if (!['supplier-sync', 'product-family', 'image-upload'].includes(queue)) {
         return ctx.badRequest('Invalid queue name');
       }
 
@@ -306,7 +306,7 @@ export default ({
       const { queue } = ctx.params;
 
       // Validate queue name
-      if (!['supplier-sync', 'product-family', 'image-upload', 'meilisearch-sync'].includes(queue)) {
+      if (!['supplier-sync', 'product-family', 'image-upload'].includes(queue)) {
         return ctx.badRequest('Invalid queue name');
       }
 


### PR DESCRIPTION
## Problem

Hotfix for a crash introduced by #41. The Queue Dashboard admin page at `https://cms.atlas.solslab.dev/admin/queue-dashboard` fails to load with:

```
TypeError: Cannot read properties of undefined (reading 'paused')
    at A (QueueDashboard-*.js:1:321)
```

## Root cause

#41 removed the `meilisearch-sync` queue from the backend (4 queues → 3) but missed matching references in the Strapi admin UI. `backend/src/admin/pages/QueueManagement/index.tsx` passed `allStats.meilisearchSync` to a `QueueCard`, but the backend's `getAllStats()` no longer returns that field. `QueueCard.tsx:26` then read `stats.paused` on `undefined` and crashed the whole admin page.

## Changes

- **`admin/pages/QueueManagement/index.tsx`**: delete the `meilisearch-sync` Grid.Item. Widen the remaining `image-upload` card from `col=4` to `col=12` (it was one of two in a row; now full-width). Rename the section label from "Processing & Storage" to "Image Processing" to match the narrowed scope. Remove the `meilisearch-sync` `SingleSelectOption` from the queue filter dropdown.
- **`admin/pages/QueueManagement/QueueCard.tsx`**: remove `'meilisearch-sync'` from the queue display name map. **Add a defensive `if (!stats) return null` guard** so this class of bug can never crash the whole admin page again — if the backend ever returns fewer queues than the UI expects, the missing card just won't render.
- **`admin/api/queueManager.ts`**: drop `meilisearchSync: QueueStats` from the `AllQueueStats` interface.
- **`api/queue-manager/controllers/queue-manager.ts`**: narrow the queue-name string union + 10 validation list entries from 4 queues to 3. Stale validations would have accepted requests for a queue that no longer exists in the service's `VALID_QUEUE_NAMES` list, producing confusing errors.

## Verified

- `tsc --noEmit` clean
- Grep for `meilisearch-sync` / `meilisearchSync` in `backend/src` returns only comments and explanatory text

## Stats

4 files, +20 / −27 (net −7).

## Test plan
- [ ] PR builds green
- [ ] Coolify backend redeploys
- [ ] `https://cms.atlas.solslab.dev/admin/queue-dashboard` loads without crash, shows 3 queue cards
- [ ] Image Processing card is full width
- [ ] Queue filter dropdown in Jobs section only lists the 3 live queues
- [ ] `/api/queue-manager/stats/meilisearch-sync` returns `400 Invalid queue name` (was silently routing to a dead code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
