### PR TITLE
fix: show correct variant image per color in catalog, chat, and detail

### DIFF
--- a/backend/config/plugins.ts
+++ b/backend/config/plugins.ts
@@ -28,6 +28,7 @@ export default ({ env }) => ({
             "supplier",
             "categories",
             "variants",
+            "variants.primary_image",
             "main_image",
             "gallery_images",
             "price_tiers",
@@ -38,6 +39,19 @@ export default ({ env }) => ({
           const name = entry.name || {};
           const description = entry.description || {};
           const shortDescription = entry.short_description || {};
+
+          // Build color -> primary_image URL map from variants so the
+          // frontend can display the correct image when a color filter is
+          // active. First variant per color wins (later duplicates ignored).
+          const colorImageMap: Record<string, string> = {};
+          for (const variant of entry.variants || []) {
+            const color = variant?.color;
+            const url = variant?.primary_image?.url;
+            if (color && url && !colorImageMap[color]) {
+              colorImageMap[color] = url;
+            }
+          }
+
           return {
             id: entry.documentId,
             sku: entry.sku,
@@ -62,6 +76,7 @@ export default ({ env }) => ({
             ean: entry.ean || '',
             customs_tariff_number: entry.customs_tariff_number || '',
             main_image_url: entry.main_image?.url || '',
+            color_image_map: colorImageMap,
             is_active: entry.is_active !== false,
             updated_at: entry.updatedAt,
           };

--- a/frontend/src/app/api/chat-bot/route.ts
+++ b/frontend/src/app/api/chat-bot/route.ts
@@ -164,6 +164,13 @@ export async function POST(req: Request) {
             if (k !== "limit" && v) filtersApplied[k] = v;
           }
 
+          // If the AI filtered by one or more colors, surface the first one
+          // as the "active" color so ChatProductCard can render the matching
+          // variant image from product.color_image_map.
+          const activeColor = args.colors
+            ? args.colors.split(",")[0]?.trim() || undefined
+            : undefined;
+
           try {
             const searchResult = await searchStrapi(params);
             const products = searchResult.data || [];
@@ -175,6 +182,7 @@ export async function POST(req: Request) {
                 products: [],
                 total: 0,
                 filters_applied: filtersApplied,
+                active_color: activeColor,
                 no_results: true,
               };
             }
@@ -187,6 +195,7 @@ export async function POST(req: Request) {
               products: richProducts,
               total,
               filters_applied: filtersApplied,
+              active_color: activeColor,
               no_results: false,
             };
           } catch {

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -41,6 +41,7 @@ type StoredPart =
       products: RichProduct[];
       total: number;
       noResults: boolean;
+      activeColor?: string;
     };
 
 const MAX_CONVERSATIONS = 30;
@@ -174,10 +175,17 @@ const SUGGESTIONS = [
 
 const ChatProductCard = React.memo(function ChatProductCard({
   product,
+  activeColor,
 }: {
   product: RichProduct;
+  activeColor?: string;
 }) {
-  const imgSrc = product.main_image_url || product.main_image_thumbnail_url;
+  const variantImg =
+    activeColor && product.color_image_map?.[activeColor]
+      ? product.color_image_map[activeColor]
+      : undefined;
+  const imgSrc =
+    variantImg || product.main_image_url || product.main_image_thumbnail_url;
   const priceLabel = formatPriceRange(
     product.price_min,
     product.price_max,
@@ -268,6 +276,9 @@ interface ToolOutput {
   total?: number;
   no_results?: boolean;
   filters_applied?: Record<string, unknown>;
+  /** First color from the AI's `colors` filter, if any. Used to pick the
+   *  matching variant image in each ChatProductCard. */
+  active_color?: string;
   error?: string;
 }
 
@@ -320,7 +331,11 @@ const InlineProductGrid = React.memo(function InlineProductGrid({
     <div className="mt-2 space-y-2">
       <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
         {products.map((p) => (
-          <ChatProductCard key={p.id} product={p} />
+          <ChatProductCard
+            key={p.id}
+            product={p}
+            activeColor={output.active_color}
+          />
         ))}
       </div>
       {total > products.length && (
@@ -382,6 +397,7 @@ function StoredMessageBubble({ msg }: { msg: StoredMessage }) {
                   products: part.products,
                   total: part.total,
                   no_results: part.noResults,
+                  active_color: part.activeColor,
                 }}
               />
             );
@@ -471,6 +487,7 @@ export default function ChatPage() {
             products: output.products || [],
             total: output.total || 0,
             noResults: output.no_results || false,
+            activeColor: output.active_color,
           });
         }
       }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -312,6 +312,7 @@ function CatalogContent() {
             total={total}
             loading={loading}
             chatOpen={isChatOpen}
+            activeColor={params.colors?.split(",")[0] || undefined}
           />
 
           {/* Pagination */}

--- a/frontend/src/app/products/[id]/ProductDetail.tsx
+++ b/frontend/src/app/products/[id]/ProductDetail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { cn, formatPrice, getLocalizedText } from "@/lib/utils";
@@ -88,25 +88,47 @@ export function ProductDetail({ product }: ProductDetailProps) {
   const description = getLocalizedText(product.description);
   const material = getLocalizedText(product.material);
 
-  // Gather all images
-  const allImages: StrapiMedia[] = [];
-  if (product.main_image) allImages.push(product.main_image);
-  if (product.model_image) allImages.push(product.model_image);
-  if (product.gallery_images) allImages.push(...product.gallery_images);
+  // Product-level fallback gallery (main + model + gallery).
+  const productLevelImages = useMemo(() => {
+    const imgs: StrapiMedia[] = [];
+    if (product.main_image) imgs.push(product.main_image);
+    if (product.model_image) imgs.push(product.model_image);
+    if (product.gallery_images) imgs.push(...product.gallery_images);
+    return imgs;
+  }, [product]);
 
   // Group variants by color
-  const colorGroups = new Map<string, ProductVariant[]>();
-  for (const v of product.variants || []) {
-    const color = v.color || "Default";
-    if (!colorGroups.has(color)) colorGroups.set(color, []);
-    colorGroups.get(color)!.push(v);
-  }
+  const colorGroups = useMemo(() => {
+    const groups = new Map<string, ProductVariant[]>();
+    for (const v of product.variants || []) {
+      const color = v.color || "Default";
+      if (!groups.has(color)) groups.set(color, []);
+      groups.get(color)!.push(v);
+    }
+    return groups;
+  }, [product.variants]);
 
   const [selectedColor, setSelectedColor] = useState<string>(
     colorGroups.keys().next().value || "",
   );
 
-  const variantsForColor = colorGroups.get(selectedColor) || [];
+  const variantsForColor = useMemo(
+    () => colorGroups.get(selectedColor) || [],
+    [colorGroups, selectedColor],
+  );
+
+  // Images shown in the gallery: prefer the images from variants of the
+  // currently-selected color. Fall back to product-level images when the
+  // variants have no primary/gallery images of their own (graceful for
+  // products whose variants haven't had their images populated yet).
+  const displayedImages = useMemo(() => {
+    const variantImages: StrapiMedia[] = [];
+    for (const v of variantsForColor) {
+      if (v.primary_image) variantImages.push(v.primary_image);
+      if (v.gallery_images) variantImages.push(...v.gallery_images);
+    }
+    return variantImages.length > 0 ? variantImages : productLevelImages;
+  }, [variantsForColor, productLevelImages]);
 
   // Price display
   const priceLabel = (() => {
@@ -141,8 +163,12 @@ export function ProductDetail({ product }: ProductDetailProps) {
       </Link>
 
       <div className="grid gap-8 md:grid-cols-2 lg:gap-12">
-        {/* Left: Images */}
-        <ImageGallery images={allImages} />
+        {/* Left: Images — keyed on selectedColor so the internal thumbnail
+         *  state (`selected` index) resets when the user switches colors. */}
+        <ImageGallery
+          key={selectedColor || "default"}
+          images={displayedImages}
+        />
 
         {/* Right: Info */}
         <div className="flex flex-col gap-5">

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -9,9 +9,16 @@ import type { MeilisearchProduct } from "@/lib/types";
 
 interface ProductCardProps {
   product: MeilisearchProduct;
+  /**
+   * Active color filter from the catalog state. When set, the card will
+   * prefer that color's variant image over the product's default main_image.
+   * Falls back to main_image_url if the product has no variant image for
+   * the active color (older indexed documents, or color not in map).
+   */
+  activeColor?: string;
 }
 
-export function ProductCard({ product }: ProductCardProps) {
+export function ProductCard({ product, activeColor }: ProductCardProps) {
   const name =
     product.name_en ||
     product.name_de ||
@@ -19,7 +26,12 @@ export function ProductCard({ product }: ProductCardProps) {
     product.name_es ||
     product.sku;
 
-  const imgSrc = product.main_image_url || product.main_image_thumbnail_url;
+  const variantImg =
+    activeColor && product.color_image_map?.[activeColor]
+      ? product.color_image_map[activeColor]
+      : undefined;
+  const imgSrc =
+    variantImg || product.main_image_url || product.main_image_thumbnail_url;
   const maxSwatches = 5;
   const visibleColors = product.colors.slice(0, maxSwatches);
   const overflowCount = product.colors.length - maxSwatches;

--- a/frontend/src/components/ProductGrid.tsx
+++ b/frontend/src/components/ProductGrid.tsx
@@ -10,6 +10,9 @@ interface ProductGridProps {
   total: number;
   loading: boolean;
   chatOpen?: boolean;
+  /** Active color filter (first color if multi-selected). Forwarded to
+   *  ProductCard so each card renders the matching variant image. */
+  activeColor?: string;
 }
 
 function SkeletonCard() {
@@ -36,6 +39,7 @@ export function ProductGrid({
   total,
   loading,
   chatOpen = false,
+  activeColor,
 }: ProductGridProps) {
   const gridCols = chatOpen
     ? "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
@@ -89,7 +93,11 @@ export function ProductGrid({
       <div className={cn("grid gap-4", gridCols)}>
         <AnimatePresence mode="popLayout">
           {products.map((product) => (
-            <ProductCard key={product.id} product={product} />
+            <ProductCard
+              key={product.id}
+              product={product}
+              activeColor={activeColor}
+            />
           ))}
         </AnimatePresence>
       </div>

--- a/frontend/src/lib/chat-search.ts
+++ b/frontend/src/lib/chat-search.ts
@@ -60,6 +60,7 @@ export function mapToRichProduct(p: Record<string, unknown>): RichProduct {
     main_image_url: (p.main_image_url as string) || undefined,
     main_image_thumbnail_url:
       (p.main_image_thumbnail_url as string) || undefined,
+    color_image_map: (p.color_image_map as Record<string, string>) || undefined,
     description,
   };
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -66,6 +66,11 @@ export interface MeilisearchProduct {
   // Images
   main_image_url?: string;
   main_image_thumbnail_url?: string;
+
+  // Per-color variant image map (populated by the backend transformEntry).
+  // Keys are color names (e.g. "Red"), values are the primary_image URL of
+  // the first variant with that color. Undefined for old index documents.
+  color_image_map?: Record<string, string>;
 }
 
 // ---------------------------------------------------------------------------
@@ -266,6 +271,7 @@ export interface RichProduct {
   supplier_name: string;
   main_image_url?: string;
   main_image_thumbnail_url?: string;
+  color_image_map?: Record<string, string>;
   description?: string;
 }
 


### PR DESCRIPTION
## Problem

The catalog sidebar color filter, the chat `searchProducts` tool, and the product detail color swatches all show the **wrong image for roughly half of all products** whose "hero" variant doesn't match the requested color.

### Verified against staging before writing code

Filtering jackets by Red returns 39 products. **19 of 39 (49%) have a non-red hero**:

```
A461-2261044  colors=['White', 'Red', ...]   → card shows white jacket
A461-2261049  colors=['Orange', 'Red', ...]  → card shows orange jacket
A461-2261066  colors=['Blue', 'Orange', ...] → card shows blue jacket
A403-CGJG003  colors=['Black', 'Green', ...] → card shows black jacket
... 15 more
```

Filtering by Blue on the same category: 3 of the first 6 results had `Red` as their hero — same bug, ~50% failure rate.

**The chat path appeared to work on a spot-check, but that was pure sample bias.** The AI's first 8 results happened to all fall inside the red-first subset (`A461-150xxx` / `A461-211xxxx`). The chat uses `main_image_url` from the exact same field as the catalog (`chat/page.tsx:ChatProductCard` line 180 is identical to `components/ProductCard.tsx` line 22), so the underlying bug is the same.

## Root cause

`Product.main_image` is set by whichever variant is processed first during sync — via `updateParentProduct: true` on the first image-upload job. For James Harvest jackets, Promidata lists red first → red becomes the hero. For most other categories it's another color. The Meilisearch product document stored only `main_image_url` (a single URL per product, whatever the hero is), with no mapping from color → variant image. Every color-filtered query therefore displayed the hero image regardless of the selected color.

The product detail page had a separate but related bug: clicking a color swatch updated `selectedColor` state, but `allImages` was built from only `product.main_image` / `model_image` / `gallery_images` at render time, never reactive to the selected color. Variant `primary_image` / `gallery_images` were fetched in the populated response but never read.

## Fix

### Backend — `backend/config/plugins.ts`
- Deepen the Meilisearch plugin populate from `variants` to include `variants.primary_image`.
- Build a `color_image_map` (`Record<color, primary_image_url>`) in the product transformEntry. First variant per color wins.
- Add as a new field on every indexed document. **Requires a re-index** to populate on existing data (see below).

### Catalog path — `ProductCard.tsx` / `ProductGrid.tsx` / `app/page.tsx` / `lib/types.ts`
- Add `color_image_map` to `MeilisearchProduct` type.
- `ProductCard` accepts `activeColor?: string` prop; when set, prefers `product.color_image_map[activeColor]` over `main_image_url`.
- `ProductGrid` forwards `activeColor` to each card.
- `app/page.tsx` derives `activeColor` from `params.colors?.split(",")[0]` — first color when multi-selected — and passes to `ProductGrid`.

### Chat path — `chat-search.ts` / `chat-bot/route.ts` / `chat/page.tsx`
- `mapToRichProduct` copies `color_image_map` onto `RichProduct`.
- When the AI's `searchProducts` tool call passes a `colors` filter, the route surfaces the first color as `active_color` in the tool output.
- `ToolOutput`, `ChatProductCard`, and `InlineProductGrid` all thread `active_color` through.
- `StoredPart.activeColor` is added to localStorage persistence so restored conversations also render the correct variant image. Both live and restore serialization paths carry it through.

### Product detail — `app/products/[id]/ProductDetail.tsx`
- Hoist `productLevelImages` and `colorGroups` into `useMemo` for stable references.
- `variantsForColor` also becomes a `useMemo` (react-hooks/exhaustive-deps compliance).
- New `displayedImages` useMemo: prefers variant `primary_image` + `gallery_images` from the selected color's variants; falls back to `productLevelImages` if the variant has no populated images (graceful for older data).
- `<ImageGallery key={selectedColor} images={displayedImages} />` — the `key` forces React to remount when the user switches colors, resetting the gallery's internal `selected` thumbnail index state. Without this, switching from a 5-image red variant to a 2-image blue variant would crash on `images[selected].url` when `selected === 3`.

## Verified

- `npx tsc --noEmit` clean on both backend and frontend
- `npx eslint` clean on all 9 touched frontend files (one warning fixed mid-way — `variantsForColor` new-array-per-render)
- `npx prettier --check` passes on all 9 files

## Requires re-index after merge

The backend change adds `color_image_map` to the `pim_products` Meilisearch document shape. Existing indexed documents will fall back to `main_image_url` (same behavior as today — no regression, just not yet fixed) until products are re-indexed. The plugin re-indexes a product on every `afterUpdate` lifecycle event, so any resync of the supplier data will automatically populate the new field.

**For a clean demo state, delete and rebuild the index:**

```bash
curl -X DELETE -H "Authorization: Bearer $MEILI_KEY" \
  https://search.atlas.solslab.dev/indexes/pim_products
# Then restart Strapi (plugin recreates index) + trigger full sync
```

Since you're already planning a resync for the new staging server, this is free.

## Stats

9 files changed, +115 / −20 (net +95).

## Test plan after re-index
- [ ] Catalog sidebar: filter `Red` in jackets — A461-2261044 (previously showed white) now shows its red variant image
- [ ] Catalog sidebar: filter `Blue` in jackets — A461-150862 (previously showed red) now shows its blue variant image
- [ ] Product detail for a multi-color SKU: click red swatch → main image switches to red variant; click blue → switches to blue
- [ ] AI chat "red jackets" — returned cards show red images for ALL results, including ones from A461-22xxxxx range
- [ ] AI chat "blue jackets" — same verification, different color
- [ ] Old/unchanged products (no `color_image_map` in the indexed document) still render via `main_image_url` fallback (no crashes, no undefined access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
