### PR TITLE
fix: deduplicate gallery image URLs across Promidata languages

### DIFF
--- a/backend/src/services/promidata/transformers/variant-transformer.ts
+++ b/backend/src/services/promidata/transformers/variant-transformer.ts
@@ -492,6 +492,11 @@ class VariantTransformer {
         }
       }
 
+      // Promidata duplicates the same MediaGalleryImages across all
+      // language variants (nl, de, en, fr, es). The loop above collects
+      // them all, so deduplicate by URL to avoid 5× queue inflation.
+      result.galleryImages = [...new Set(result.galleryImages)];
+
       // If we found images, return them
       if (result.primaryImage || result.galleryImages.length > 0) {
         return result;


### PR DESCRIPTION
extractImageUrls() in variant-transformer.ts loops through all 5 Promidata language variants (nl, de, en, fr, es) and pushes every MediaGalleryImages URL into the result array. Since Promidata reuses the same images across all languages, a product with 5 gallery images gets 25 entries (5 URLs x 5 languages). This inflated the image-upload queue by ~5x: on the staging full sync, 2,425,951 image jobs were enqueued instead of ~500K.

Fix: deduplicate with a Set before returning.

Expected impact on next sync:
  Before: 127,970 variants x ~19 images/variant  = 2,425,951 jobs
  After:  127,970 variants x ~4 images/variant   = ~500,000 jobs